### PR TITLE
Direct audio

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update \
     python3-dbus \
     python3-tap \
     python3-gi \
+    libgstreamer1.0-dev \
+    libgstreamer-plugins-base1.0-dev \
     && apt-get clean -y \
     && apt-get autoremove -y \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Update repos
         run: apt update
       - name: Install dependencies
-        run: apt install -y git meson gi-docgen libgirepository1.0-dev dbus libdbus-glib-1-dev python3-dbus python3-tap python3-gi
+        run: apt install -y git meson gi-docgen libgirepository1.0-dev dbus libdbus-glib-1-dev python3-dbus python3-tap python3-gi libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
       - name: Set up permissions
         run: chown ubuntu:ubuntu .
       - name: Build libspiel

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -45,20 +45,22 @@ overview_doc = custom_target(
     capture: true
 )
 
-custom_target('libspiel-doc',
-  input: [ source_toml, spiel_gir[0] ],
-  output: 'libspiel',
-  command: [
-    gidocgen,
-    'generate',
-    gidocgen_common_args,
-    '--config=@INPUT0@',
-    '--output-dir=@OUTPUT@',
-    '--content-dir=@0@'.format(meson.current_build_dir()),
-    '@INPUT1@',
-  ],
-  build_by_default: true,
-  depends: [ spiel_iface_docs, overview_doc, urlmap_doc, logo_file ]
-  # install: true,
-  # install_dir: docs_dir,
-)
+if get_option('libspiel')
+  custom_target('libspiel-doc',
+    input: [ source_toml, spiel_gir[0] ],
+    output: 'libspiel',
+    command: [
+      gidocgen,
+      'generate',
+      gidocgen_common_args,
+      '--config=@INPUT0@',
+      '--output-dir=@OUTPUT@',
+      '--content-dir=@0@'.format(meson.current_build_dir()),
+      '@INPUT1@',
+    ],
+    build_by_default: true,
+    depends: [ spiel_iface_docs, overview_doc, urlmap_doc, logo_file ]
+    # install: true,
+    # install_dir: docs_dir,
+  )
+endif

--- a/interface/org.freedesktop.Speech.Provider.xml
+++ b/interface/org.freedesktop.Speech.Provider.xml
@@ -12,6 +12,27 @@
     end with `Speech.Provider`. For example, `org.espeak.Speech.Provider`.
   -->
   <interface name="org.freedesktop.Speech.Provider">
+  <!--
+    Synthesize:
+    @pipe_fd: File descriptor of pipe to write to.
+    @text: The text to be spoken.
+    @voice_id: The voice identifier for the voice that should be spoken.
+    @pitch: The voice pitch in which the text should be spoken.
+    @rate: The rate in which the text should be spoken.
+
+    This is the basic synthesis method.
+    When called, the speech provider will send the synthesized output to the given file descriptor.
+    Depending on the voice's advertised format it will be raw audio or composite audio and events.
+
+    Providers should be capable of synthesizing more than one request concurrently.
+  -->
+    <method name="Synthesize">
+      <arg direction="in"  type="h" name="pipe_fd" />
+      <arg direction="in"  type="s" name="text" />
+      <arg direction="in"  type="s" name="voice_id" />
+      <arg direction="in"  type="d" name="pitch" />
+      <arg direction="in"  type="d" name="rate" />
+    </method>
 
   <!--
     GetVoices:

--- a/interface/org.freedesktop.Speech.Provider.xml
+++ b/interface/org.freedesktop.Speech.Provider.xml
@@ -25,11 +25,12 @@
     <ul>
       <li>A human readable name</li>
       <li>A unique identifier</li>
+      <li>Synthesis output format</li>
       <li>A list of languages the voice support represented as BCP 47 tags</li>
     </ul>
   -->
     <method name="GetVoices">
-      <arg name="voices" direction="out" type="a(ssas)" />
+      <arg name="voices" direction="out" type="a(sssas)" />
     </method>
 
   <!--

--- a/interface/org.freedesktop.Speech.Provider.xml
+++ b/interface/org.freedesktop.Speech.Provider.xml
@@ -12,62 +12,6 @@
     end with `Speech.Provider`. For example, `org.espeak.Speech.Provider`.
   -->
   <interface name="org.freedesktop.Speech.Provider">
-  <!--
-    Speak:
-    @task_id: A unique identifier that will be assigned to this `Speak` call.
-    @text: The text to be spoken.
-    @voice_id: The voice identifier for the voice that should be spoken.
-    @pitch: The voice pitch in which the text should be spoken.
-    @rate: The rate in which the text should be spoken.
-    @volume: The volume at which the text should be spoken.
-
-    This is the basic speech method.
-    When called, the speech provider will send the synthesized output to the default audio device.
-
-    The `task_id` argument allows this task to be identified subsequent signals or method calls such as
-    `Pause()`.
-
-    If `Speak()` is called while a previous `Speak()` task is being processed, the provider
-    **should** output both synthesis streams concurrently.
-  -->
-    <method name="Speak">
-      <arg direction="in"  type="t" name="task_id" />
-      <arg direction="in"  type="s" name="text" />
-      <arg direction="in"  type="s" name="voice_id" />
-      <arg direction="in"  type="d" name="pitch" />
-      <arg direction="in"  type="d" name="rate" />
-      <arg direction="in"  type="d" name="volume" />
-    </method>
-
-  <!--
-    Pause:
-    @task_id: A task identifier.
-
-    Pause the speech of the given identifier.
-  -->
-    <method name="Pause">
-      <arg direction="in"  type="t" name="task_id" />
-    </method>
-
-  <!--
-    Resume:
-    @task_id: A task identifier.
-
-    Resume the speech of the given identifier.
-  -->
-    <method name="Resume">
-      <arg direction="in"  type="t" name="task_id" />
-    </method>
-
-  <!--
-    Cancel:
-    @task_id: A task identifier.
-
-    Cancel the speech of the given identifier.
-  -->
-    <method name="Cancel">
-      <arg direction="in"  type="t" name="task_id" />
-    </method>
 
   <!--
     GetVoices:
@@ -87,41 +31,6 @@
     <method name="GetVoices">
       <arg name="voices" direction="out" type="a(ssas)" />
     </method>
-
-  <!--
-    SpeechStart:
-    @task_id: A task identifier.
-
-    Emitted when a speech task has started outputting audio.
-  -->
-    <signal name="SpeechStart">
-      <arg type="t" name="task_id" />
-    </signal>
-
-  <!--
-    SpeechRangeStart:
-    @task_id: A task identifier.
-    @start: Start offset of the spoken range.
-    @end: End offset of the spoken range.
-
-    Emitted when a speech task has is about to start speaking a certain range.
-    Usually this range is a single word.
-  -->
-    <signal name="SpeechRangeStart">
-      <arg type="t" name="task_id" />
-      <arg type="t" name="start" />
-      <arg type="t" name="end" />
-    </signal>
-
-  <!--
-    SpeechStart:
-    @task_id: A task identifier.
-
-    Emitted when a speech task has completed.
-  -->
-    <signal name="SpeechEnd">
-      <arg type="t" name="task_id" />
-    </signal>
 
   <!--
     VoicesChanged:

--- a/libspiel/meson.build
+++ b/libspiel/meson.build
@@ -17,6 +17,7 @@ spiel_public_sources = [
 spiel_sources = [
   spiel_public_sources,
   'spiel-registry.c',
+  'spiel-provider-src.c',
   spiel_iface_sources,
 ]
 
@@ -30,6 +31,7 @@ spiel_public_headers = [
 spiel_headers = [
   spiel_public_headers,
   'spiel-registry.h',
+  'spiel-provider-src.h',
 ]
 
 version_split = meson.project_version().split('.')
@@ -56,6 +58,7 @@ spiel_deps = [
   dependency('gio-unix-2.0'),
   dependency('gstreamer-1.0'),
   dependency('gstreamer-audio-1.0'),
+  spiel_provider_lib_dep
 ]
 
 spiel_lib = shared_library('spiel-' + api_version,

--- a/libspiel/meson.build
+++ b/libspiel/meson.build
@@ -54,6 +54,8 @@ spiel_lib_generated_headers = [
 spiel_deps = [
   dependency('gio-2.0'),
   dependency('gio-unix-2.0'),
+  dependency('gstreamer-1.0'),
+  dependency('gstreamer-audio-1.0'),
 ]
 
 spiel_lib = shared_library('spiel-' + api_version,

--- a/libspiel/spiel-provider-src.c
+++ b/libspiel/spiel-provider-src.c
@@ -1,0 +1,257 @@
+/* spiel-provider-src.c
+ *
+ * Copyright (C) 2024 Eitan Isaacson <eitan@monotonous.org>
+ *
+ * This file is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "spiel-provider-src.h"
+
+static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE (
+    "src", GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
+
+#define DEFAULT_FD 0
+
+enum
+{
+  PROP_0,
+
+  PROP_FD,
+
+  PROP_LAST
+};
+
+#define spiel_provider_src_parent_class parent_class
+G_DEFINE_TYPE (SpielProviderSrc, spiel_provider_src, GST_TYPE_PUSH_SRC);
+
+SpielProviderSrc *
+spiel_provider_src_new (gint fd)
+{
+  return g_object_new (SPIEL_TYPE_PROVIDER_SRC, "fd", fd, NULL);
+}
+
+static void spiel_provider_src_set_property (GObject *object,
+                                             guint prop_id,
+                                             const GValue *value,
+                                             GParamSpec *pspec);
+static void spiel_provider_src_get_property (GObject *object,
+                                             guint prop_id,
+                                             GValue *value,
+                                             GParamSpec *pspec);
+static void spiel_provider_src_dispose (GObject *obj);
+
+static gboolean spiel_provider_src_start (GstBaseSrc *bsrc);
+static gboolean spiel_provider_src_stop (GstBaseSrc *bsrc);
+static gboolean spiel_provider_src_unlock (GstBaseSrc *bsrc);
+static gboolean spiel_provider_src_unlock_stop (GstBaseSrc *bsrc);
+static gboolean spiel_provider_src_get_size (GstBaseSrc *src, guint64 *size);
+
+static GstFlowReturn spiel_provider_src_create (GstPushSrc *psrc,
+                                                GstBuffer **outbuf);
+
+static void
+spiel_provider_src_class_init (SpielProviderSrcClass *klass)
+{
+  GObjectClass *gobject_class;
+  GstElementClass *gstelement_class;
+  GstBaseSrcClass *gstbasesrc_class;
+  GstPushSrcClass *gstpush_src_class;
+
+  gobject_class = G_OBJECT_CLASS (klass);
+  gstelement_class = GST_ELEMENT_CLASS (klass);
+  gstbasesrc_class = GST_BASE_SRC_CLASS (klass);
+  gstpush_src_class = GST_PUSH_SRC_CLASS (klass);
+
+  gobject_class->set_property = spiel_provider_src_set_property;
+  gobject_class->get_property = spiel_provider_src_get_property;
+  gobject_class->dispose = spiel_provider_src_dispose;
+
+  g_object_class_install_property (
+      gobject_class, PROP_FD,
+      g_param_spec_int ("fd", "fd", "An open file descriptor to read from", 0,
+                        G_MAXINT, DEFAULT_FD,
+                        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS |
+                            G_PARAM_CONSTRUCT_ONLY));
+
+  gst_element_class_set_static_metadata (
+      gstelement_class, "Spiel Provider Source", "Source",
+      "Read specialized audio/event chunks from pipe",
+      "Eitan Isaacson <eitan@monotonous.org>");
+  gst_element_class_add_static_pad_template (gstelement_class, &srctemplate);
+
+  gstbasesrc_class->start = GST_DEBUG_FUNCPTR (spiel_provider_src_start);
+  gstbasesrc_class->stop = GST_DEBUG_FUNCPTR (spiel_provider_src_stop);
+  gstbasesrc_class->unlock = GST_DEBUG_FUNCPTR (spiel_provider_src_unlock);
+  gstbasesrc_class->unlock_stop =
+      GST_DEBUG_FUNCPTR (spiel_provider_src_unlock_stop);
+  gstbasesrc_class->get_size = GST_DEBUG_FUNCPTR (spiel_provider_src_get_size);
+
+  gstpush_src_class->create = GST_DEBUG_FUNCPTR (spiel_provider_src_create);
+}
+
+static void
+spiel_provider_src_init (SpielProviderSrc *spsrc)
+{
+  spsrc->curoffset = 0;
+  spsrc->reader = NULL;
+}
+
+static void
+spiel_provider_src_dispose (GObject *obj)
+{
+  SpielProviderSrc *src = SPIEL_PROVIDER_SRC (obj);
+  g_object_unref (src->reader);
+
+  G_OBJECT_CLASS (parent_class)->dispose (obj);
+}
+
+static gboolean
+spiel_provider_src_start (GstBaseSrc *bsrc)
+{
+  SpielProviderSrc *src = SPIEL_PROVIDER_SRC (bsrc);
+  gboolean got_header =
+      spiel_provider_stream_reader_get_stream_header (src->reader);
+  return got_header;
+}
+
+static gboolean
+spiel_provider_src_stop (GstBaseSrc *bsrc)
+{
+  // XXX: Do we need this?
+  return TRUE;
+}
+
+static gboolean
+spiel_provider_src_unlock (GstBaseSrc *bsrc)
+{
+  // XXX: Do we need this?
+  return TRUE;
+}
+
+static gboolean
+spiel_provider_src_unlock_stop (GstBaseSrc *bsrc)
+{
+  // XXX: Do we need this?
+  return TRUE;
+}
+
+static void
+spiel_provider_src_set_property (GObject *object,
+                                 guint prop_id,
+                                 const GValue *value,
+                                 GParamSpec *pspec)
+{
+  SpielProviderSrc *src = SPIEL_PROVIDER_SRC (object);
+
+  switch (prop_id)
+    {
+    case PROP_FD:
+
+      GST_OBJECT_LOCK (object);
+      g_assert (src->reader == NULL);
+      src->fd = g_value_get_int (value);
+      src->reader = spiel_provider_stream_reader_new (src->fd);
+      GST_OBJECT_UNLOCK (object);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+spiel_provider_src_get_property (GObject *object,
+                                 guint prop_id,
+                                 GValue *value,
+                                 GParamSpec *pspec)
+{
+  SpielProviderSrc *src = SPIEL_PROVIDER_SRC (object);
+
+  switch (prop_id)
+    {
+    case PROP_FD:
+      g_value_set_int (value, src->fd);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+    }
+}
+
+static GstFlowReturn
+spiel_provider_src_create (GstPushSrc *psrc, GstBuffer **outbuf)
+{
+  SpielProviderSrc *src;
+  GstBuffer *buf;
+  guint8 *chunk;
+  guint32 chunk_size;
+  gboolean success;
+
+  src = SPIEL_PROVIDER_SRC (psrc);
+
+  while (TRUE)
+    {
+      SpielProviderEventType event_type;
+      guint32 range_start;
+      guint32 range_end;
+      char *mark_name = NULL;
+      success = spiel_provider_stream_reader_get_event (
+          src->reader, &event_type, &range_start, &range_end, &mark_name);
+      if (!success)
+        {
+          break;
+        }
+
+      gst_element_post_message (
+          GST_ELEMENT_CAST (src),
+          gst_message_new_element (
+              GST_OBJECT_CAST (src),
+              gst_structure_new ("SpielGoingToSpeak", "event_type", G_TYPE_UINT,
+                                 event_type, "range_start", G_TYPE_UINT,
+                                 range_start, "range_end", G_TYPE_UINT,
+                                 range_end, "mark_name", G_TYPE_STRING,
+                                 mark_name, NULL)));
+      g_free (mark_name);
+    }
+
+  success =
+      spiel_provider_stream_reader_get_audio (src->reader, &chunk, &chunk_size);
+
+  if (!success)
+    {
+      g_assert (chunk_size == 0);
+      GST_DEBUG_OBJECT (psrc, "Read 0 bytes. EOS.");
+      return GST_FLOW_EOS;
+    }
+
+  buf = gst_buffer_new_wrapped (chunk, chunk_size);
+
+  GST_BUFFER_OFFSET (buf) = src->curoffset;
+  GST_BUFFER_TIMESTAMP (buf) = GST_CLOCK_TIME_NONE;
+  src->curoffset += chunk_size;
+
+  *outbuf = buf;
+
+  return GST_FLOW_OK;
+}
+
+static gboolean
+spiel_provider_src_get_size (GstBaseSrc *bsrc, guint64 *size)
+{
+  // XXX: Get rid of this?
+  return FALSE;
+}

--- a/libspiel/spiel-provider-src.h
+++ b/libspiel/spiel-provider-src.h
@@ -1,0 +1,71 @@
+/* spiel-provider-src.c
+ *
+ * Copyright (C) 2024 Eitan Isaacson <eitan@monotonous.org>
+ *
+ * This file is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __SPIEL_PROVIDER_SRC_H__
+#define __SPIEL_PROVIDER_SRC_H__
+
+#include <gst/base/gstpushsrc.h>
+#include <gst/gst.h>
+#include <spiel-provider.h>
+
+G_BEGIN_DECLS
+
+#define SPIEL_TYPE_PROVIDER_SRC (spiel_provider_src_get_type ())
+#define SPIEL_PROVIDER_SRC(obj)                                                \
+  (G_TYPE_CHECK_INSTANCE_CAST ((obj), SPIEL_TYPE_PROVIDER_SRC,                 \
+                               SpielProviderSrc))
+#define SPIEL_PROVIDER_SRC_CLASS(klass)                                        \
+  (G_TYPE_CHECK_CLASS_CAST ((klass), SPIEL_TYPE_PROVIDER_SRC,                  \
+                            SpielProviderSrcClass))
+#define GST_IS_FD_SRC(obj)                                                     \
+  (G_TYPE_CHECK_INSTANCE_TYPE ((obj), SPIEL_TYPE_PROVIDER_SRC))
+#define GST_IS_FD_SRC_CLASS(klass)                                             \
+  (G_TYPE_CHECK_CLASS_TYPE ((klass), SPIEL_TYPE_PROVIDER_SRC))
+
+typedef struct _SpielProviderSrc SpielProviderSrc;
+typedef struct _SpielProviderSrcClass SpielProviderSrcClass;
+
+/**
+ * SpielProviderSrc:
+ *
+ * Opaque #SpielProviderSrc data structure.
+ */
+struct _SpielProviderSrc
+{
+  GstPushSrc element;
+
+  /* fd and flag indicating whether fd is seekable */
+  gint fd;
+
+  gulong curoffset; /* current offset in file */
+
+  SpielProviderStreamReader *reader;
+};
+
+struct _SpielProviderSrcClass
+{
+  GstPushSrcClass parent_class;
+};
+
+G_GNUC_INTERNAL GType spiel_provider_src_get_type (void);
+
+SpielProviderSrc *spiel_provider_src_new (gint fd);
+
+G_END_DECLS
+
+#endif /* __SPIEL_PROVIDER_SRC_H__ */

--- a/libspiel/spiel-registry.c
+++ b/libspiel/spiel-registry.c
@@ -124,16 +124,17 @@ _add_provider_with_voices (SpielRegistry *self,
     {
       const char *name = NULL;
       const char *identifier = NULL;
+      const char *output_format = NULL;
       const char **languages = NULL;
 
-      g_variant_get_child (voices, i, "(&s&s^a&s)", &name, &identifier,
-                           &languages);
-      g_hash_table_insert (voices_hashset,
-                           g_object_new (SPIEL_TYPE_VOICE, "name", name,
-                                         "identifier", identifier, "languages",
-                                         languages, "provider-name",
-                                         provider_name, NULL),
-                           NULL);
+      g_variant_get_child (voices, i, "(&s&s&s^a&s)", &name, &identifier,
+                           &output_format, &languages);
+      g_hash_table_insert (
+          voices_hashset,
+          g_object_new (SPIEL_TYPE_VOICE, "name", name, "identifier",
+                        identifier, "languages", languages, "provider-name",
+                        provider_name, "output-format", output_format, NULL),
+          NULL);
 
       g_free (languages);
     }

--- a/libspiel/spiel-registry.c
+++ b/libspiel/spiel-registry.c
@@ -21,6 +21,7 @@
 #include "spiel-registry.h"
 
 #include <gio/gio.h>
+#include <gst/gst.h>
 
 #define PROVIDER_SUFFIX ".Speech.Provider"
 #define GSETTINGS_SCHEMA "org.monotonous.libspiel"
@@ -604,6 +605,7 @@ spiel_registry_get_finish (GAsyncResult *result, GError **error)
     {
       if (sRegistry == NULL)
         {
+          gst_init_check (NULL, NULL, error);
           sRegistry = SPIEL_REGISTRY (object);
         }
       g_assert (sRegistry == SPIEL_REGISTRY (object));
@@ -620,6 +622,7 @@ spiel_registry_get_sync (GCancellable *cancellable, GError **error)
 {
   if (sRegistry == NULL)
     {
+      gst_init_check (NULL, NULL, error);
       sRegistry =
           g_initable_new (SPIEL_TYPE_REGISTRY, cancellable, error, NULL);
     }

--- a/libspiel/spiel-speaker.h
+++ b/libspiel/spiel-speaker.h
@@ -58,6 +58,7 @@ GQuark spiel_error_quark (void);
 /**
  * SpielError:
  * @SPIEL_ERROR_NO_PROVIDERS: No speech providers are available
+ * @SPIEL_ERROR_MISCONFIGURED_VOICE: Voice is not configured correctly
  * @SPIEL_ERROR_PROVIDER_UNEXPECTEDLY_DIED: Speech provider unexpectedly
  * died
  * @SPIEL_ERROR_INTERNAL_PROVIDER_FAILURE: Internal error in speech
@@ -69,6 +70,7 @@ GQuark spiel_error_quark (void);
 typedef enum /*<underscore_name=spiel_error>*/
 {
   SPIEL_ERROR_NO_PROVIDERS,
+  SPIEL_ERROR_MISCONFIGURED_VOICE,
   SPIEL_ERROR_PROVIDER_UNEXPECTEDLY_DIED,
   SPIEL_ERROR_INTERNAL_PROVIDER_FAILURE,
 } SpielError;

--- a/libspiel/spiel-voice.c
+++ b/libspiel/spiel-voice.c
@@ -43,6 +43,7 @@ typedef struct
   char *identifier;
   char **languages;
   char *provider_name;
+  char *output_format;
 } SpielVoicePrivate;
 
 G_DEFINE_FINAL_TYPE_WITH_PRIVATE (SpielVoice, spiel_voice, G_TYPE_OBJECT)
@@ -54,6 +55,7 @@ enum
   PROP_IDENTIFIER,
   PROP_LANGUAGES,
   PROP_PROVIDER_NAME,
+  PROP_OUTPUT_FORMAT,
   N_PROPS
 };
 
@@ -105,6 +107,22 @@ spiel_voice_get_provider_name (SpielVoice *self)
 {
   SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
   return priv->provider_name;
+}
+
+/**
+ * spiel_voice_get_output_format: (get-property output-format)
+ * @self: a #SpielVoice
+ *
+ * Fetches the output format the voice uses
+ *
+ * Returns: the output format. This string is
+ *   owned by the voice and must not be modified or freed.
+ */
+const char *
+spiel_voice_get_output_format (SpielVoice *self)
+{
+  SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
+  return priv->output_format;
 }
 
 /**
@@ -233,6 +251,9 @@ spiel_voice_get_property (GObject *object,
     case PROP_PROVIDER_NAME:
       g_value_set_string (value, priv->provider_name);
       break;
+    case PROP_OUTPUT_FORMAT:
+      g_value_set_string (value, priv->output_format);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -267,6 +288,11 @@ spiel_voice_set_property (GObject *object,
       g_clear_pointer (&priv->provider_name, g_free);
       priv->provider_name = g_value_dup_string (value);
       g_object_notify (G_OBJECT (self), "provider-name");
+      break;
+    case PROP_OUTPUT_FORMAT:
+      g_clear_pointer (&priv->output_format, g_free);
+      priv->output_format = g_value_dup_string (value);
+      g_object_notify (G_OBJECT (self), "output-format");
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -323,6 +349,16 @@ spiel_voice_class_init (SpielVoiceClass *klass)
    */
   properties[PROP_PROVIDER_NAME] = g_param_spec_string (
       "provider-name", NULL, NULL, NULL /* default value */,
+      G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+  /**
+   * SpielVoice:output-format: (getter get_output_format)
+   *
+   * The audio output format for the voice.
+   *
+   */
+  properties[PROP_OUTPUT_FORMAT] = g_param_spec_string (
+      "output-format", NULL, NULL, NULL /* default value */,
       G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class, N_PROPS, properties);

--- a/libspiel/spiel-voice.h
+++ b/libspiel/spiel-voice.h
@@ -32,6 +32,8 @@ const char *spiel_voice_get_identifier (SpielVoice *self);
 
 const char *spiel_voice_get_provider_name (SpielVoice *self);
 
+const char *spiel_voice_get_output_format (SpielVoice *self);
+
 const char *const *spiel_voice_get_languages (SpielVoice *self);
 
 guint spiel_voice_hash (SpielVoice *self);

--- a/libspielprovider/COPYING
+++ b/libspielprovider/COPYING
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/libspielprovider/meson.build
+++ b/libspielprovider/meson.build
@@ -1,0 +1,73 @@
+spiel_provider_sources = [
+  'spiel-provider-stream-reader.c',
+  'spiel-provider-stream-writer.c',
+]
+
+spiel_provider_headers = [
+  'spiel-provider.h',
+  'spiel-provider-common.h',
+  'spiel-provider-stream-reader.h',
+  'spiel-provider-stream-writer.h',
+]
+
+version_split = meson.project_version().split('.')
+version_conf = configuration_data()
+version_conf.set('VERSION', meson.project_version())
+version_conf.set('MAJOR_VERSION', version_split[0])
+version_conf.set('MINOR_VERSION', version_split[1])
+version_conf.set('MICRO_VERSION', version_split[2])
+
+spiel_provider_version_h = configure_file(
+          input: 'spiel-provider-version.h.in',
+         output: 'spiel-provider-version.h',
+  configuration: version_conf,
+        install: true,
+    install_dir: join_paths(get_option('includedir'), 'spiel-provider')
+)
+
+spiel_provider_lib_generated_headers = [
+  spiel_provider_version_h,
+]
+
+spiel_provider_deps = [
+  dependency('gobject-2.0'),
+]
+
+spiel_provider_lib = shared_library('spiel-provider-' + api_version,
+  spiel_provider_sources,
+  dependencies: spiel_provider_deps,
+  install: true,
+)
+
+spiel_provider_lib_dep = declare_dependency(
+  sources: spiel_provider_lib_generated_headers,
+  dependencies: spiel_provider_deps,
+  link_with: spiel_provider_lib,
+  include_directories: include_directories('.'),
+)
+
+install_headers(spiel_provider_headers, subdir: 'spiel-provider')
+
+pkg = import('pkgconfig')
+pkg.generate(
+  description: 'A shared library for speech synthesis clients',
+    libraries: spiel_provider_lib,
+         name: 'spiel-provider',
+     filebase: 'spiel-provider-' + api_version,
+      version: meson.project_version(),
+      subdirs: 'spiel-provider',
+     requires: 'gobject-2.0'
+)
+
+gnome = import('gnome')
+spiel_provider_gir = gnome.generate_gir(spiel_provider_lib,
+            sources: spiel_provider_headers + spiel_provider_sources,
+            nsversion: api_version,
+            namespace: 'SpielProvider',
+            header: 'spiel-provider/spiel-provider.h',
+        symbol_prefix: 'spiel_provider',
+    identifier_prefix: 'SpielProvider',
+             includes: [ 'GObject-2.0' ],
+              install: true,
+              export_packages: 'spiel-provider',
+)

--- a/libspielprovider/spiel-provider-common.h
+++ b/libspielprovider/spiel-provider-common.h
@@ -1,0 +1,55 @@
+/* spiel-provider-common.h
+ *
+ * Copyright (C) 2024 Eitan Isaacson <eitan@monotonous.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+G_BEGIN_DECLS
+
+#define SPIEL_PROVIDER_STREAM_PROTOCOL_VERSION "0.01"
+
+typedef struct __attribute__ ((__packed__))
+{
+  char version[4];
+} SpielProviderStreamHeader;
+
+typedef enum __attribute__ ((__packed__))
+{
+  SPIEL_PROVIDER_CHUNK_TYPE_NONE,
+  SPIEL_PROVIDER_CHUNK_TYPE_AUDIO,
+  SPIEL_PROVIDER_CHUNK_TYPE_EVENT,
+} SpielProviderChunkType;
+
+typedef enum __attribute__ ((__packed__))
+{
+  SPIEL_PROVIDER_EVENT_TYPE_NONE,
+  SPIEL_PROVIDER_EVENT_TYPE_WORD,
+  SPIEL_PROVIDER_EVENT_TYPE_SENTENCE,
+  SPIEL_PROVIDER_EVENT_TYPE_RANGE,
+  SPIEL_PROVIDER_EVENT_TYPE_MARK,
+} SpielProviderEventType;
+
+typedef struct __attribute__ ((__packed__))
+{
+  guint8 event_type;
+  guint32 range_start;
+  guint32 range_end;
+  guint32 mark_name_length;
+} SpielProviderEventData;
+
+G_END_DECLS

--- a/libspielprovider/spiel-provider-stream-reader.c
+++ b/libspielprovider/spiel-provider-stream-reader.c
@@ -1,0 +1,273 @@
+/* spiel-provider-stream-reader.c
+ *
+ * Copyright (C) 2024 Eitan Isaacson <eitan@monotonous.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "spiel-provider.h"
+
+#include "spiel-provider-stream-reader.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+struct _SpielProviderStreamReader
+{
+  GObject parent_instance;
+};
+
+typedef struct
+{
+  gint fd;
+  gboolean stream_header_recieved;
+  SpielProviderChunkType next_chunk_type;
+} SpielProviderStreamReaderPrivate;
+
+G_DEFINE_FINAL_TYPE_WITH_PRIVATE (SpielProviderStreamReader,
+                                  spiel_provider_stream_reader,
+                                  G_TYPE_OBJECT)
+
+enum
+{
+  PROP_0,
+  PROP_FD,
+  N_PROPS
+};
+
+static GParamSpec *properties[N_PROPS];
+
+/**
+ * spiel_provider_stream_reader_new: (constructor)
+ * @fd: The file descriptor for a pipe
+ *
+ * Creates a new #SpielProviderStreamReader.
+ *
+ * Returns: The new #SpielProviderStreamReader.
+ */
+SpielProviderStreamReader *
+spiel_provider_stream_reader_new (gint fd)
+{
+  if (fcntl (fd, F_GETFD) == -1)
+    {
+      g_warning ("Bad file descriptor");
+      return NULL;
+    }
+
+  return g_object_new (SPIEL_PROVIDER_TYPE_STREAM_READER, "fd", fd, NULL);
+}
+
+/**
+ * spiel_provider_stream_reader_close:
+ *
+ * Close the pipe.
+ *
+ */
+void
+spiel_provider_stream_reader_close (SpielProviderStreamReader *self)
+{
+  SpielProviderStreamReaderPrivate *priv =
+      spiel_provider_stream_reader_get_instance_private (self);
+  close (priv->fd);
+  priv->fd = -1;
+}
+
+/**
+ * spiel_provider_stream_reader_get_stream_header:
+ *
+ * Retrieves stream header.
+ *
+ * Returns: %TRUE if header successfully recieved.
+ */
+gboolean
+spiel_provider_stream_reader_get_stream_header (SpielProviderStreamReader *self)
+{
+  SpielProviderStreamReaderPrivate *priv =
+      spiel_provider_stream_reader_get_instance_private (self);
+  SpielProviderStreamHeader header;
+  g_assert (!priv->stream_header_recieved);
+  read (priv->fd, &header, sizeof (SpielProviderStreamHeader));
+  priv->stream_header_recieved = TRUE;
+  return g_str_equal (header.version, SPIEL_PROVIDER_STREAM_PROTOCOL_VERSION);
+}
+
+static SpielProviderChunkType
+_get_next_chunk_type (SpielProviderStreamReader *self)
+{
+  SpielProviderStreamReaderPrivate *priv =
+      spiel_provider_stream_reader_get_instance_private (self);
+  if (priv->next_chunk_type == SPIEL_PROVIDER_CHUNK_TYPE_NONE)
+    {
+      read (priv->fd, &priv->next_chunk_type, sizeof (SpielProviderChunkType));
+    }
+  return priv->next_chunk_type;
+}
+
+/**
+ * spiel_provider_stream_reader_get_audio:
+ * @chunk: (out) (array length=chunk_size) (transfer full): Location to
+ *        store audio data
+ * @chunk_size: (out): Location to store size of chunk
+ *
+ * Retrieves audio data
+ *
+ * Returns: (skip): %TRUE if the call succeeds.
+ */
+gboolean
+spiel_provider_stream_reader_get_audio (SpielProviderStreamReader *self,
+                                        guint8 **chunk,
+                                        guint32 *chunk_size)
+{
+  SpielProviderStreamReaderPrivate *priv =
+      spiel_provider_stream_reader_get_instance_private (self);
+  SpielProviderChunkType chunk_type = _get_next_chunk_type (self);
+  g_assert (priv->stream_header_recieved);
+  if (chunk_type != SPIEL_PROVIDER_CHUNK_TYPE_AUDIO)
+    {
+      *chunk_size = 0;
+      return FALSE;
+    }
+
+  read (priv->fd, chunk_size, sizeof (guint32));
+  *chunk = g_malloc (*chunk_size * sizeof (guint8));
+  read (priv->fd, *chunk, *chunk_size * sizeof (guint8));
+  priv->next_chunk_type = SPIEL_PROVIDER_CHUNK_TYPE_NONE;
+  return TRUE;
+}
+
+/**
+ * spiel_provider_stream_reader_get_event:
+ * @event_type: (out): type of event
+ * @range_start: (out): text range start
+ * @range_end: (out): text range end
+ * @mark_name: (out): mark name
+ *
+ * Retrieves event data
+ *
+ * Returns: (skip): %TRUE if the call succeeds.
+ */
+gboolean
+spiel_provider_stream_reader_get_event (SpielProviderStreamReader *self,
+                                        SpielProviderEventType *event_type,
+                                        guint32 *range_start,
+                                        guint32 *range_end,
+                                        char **mark_name)
+{
+  SpielProviderStreamReaderPrivate *priv =
+      spiel_provider_stream_reader_get_instance_private (self);
+  SpielProviderChunkType chunk_type = _get_next_chunk_type (self);
+  SpielProviderEventData event_data;
+  g_assert (priv->stream_header_recieved);
+  if (chunk_type != SPIEL_PROVIDER_CHUNK_TYPE_EVENT)
+    {
+      *event_type = SPIEL_PROVIDER_EVENT_TYPE_NONE;
+      return FALSE;
+    }
+  read (priv->fd, &event_data, sizeof (SpielProviderEventData));
+  *event_type = event_data.event_type;
+  *range_start = event_data.range_start;
+  *range_end = event_data.range_end;
+  *mark_name = NULL;
+  if (event_data.mark_name_length)
+    {
+      char *name = g_malloc0 (event_data.mark_name_length * sizeof (char) + 1);
+      read (priv->fd, name, event_data.mark_name_length * sizeof (char));
+      *mark_name = name;
+    }
+  priv->next_chunk_type = SPIEL_PROVIDER_CHUNK_TYPE_NONE;
+  return TRUE;
+}
+
+static void
+spiel_provider_stream_reader_finalize (GObject *object)
+{
+  SpielProviderStreamReader *self = (SpielProviderStreamReader *) object;
+  SpielProviderStreamReaderPrivate *priv =
+      spiel_provider_stream_reader_get_instance_private (self);
+
+  close (priv->fd);
+  G_OBJECT_CLASS (spiel_provider_stream_reader_parent_class)->finalize (object);
+}
+
+static void
+spiel_provider_stream_reader_get_property (GObject *object,
+                                           guint prop_id,
+                                           GValue *value,
+                                           GParamSpec *pspec)
+{
+  SpielProviderStreamReader *self = SPIEL_PROVIDER_STREAM_READER (object);
+  SpielProviderStreamReaderPrivate *priv =
+      spiel_provider_stream_reader_get_instance_private (self);
+
+  switch (prop_id)
+    {
+    case PROP_FD:
+      g_value_set_int (value, priv->fd);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+spiel_provider_stream_reader_set_property (GObject *object,
+                                           guint prop_id,
+                                           const GValue *value,
+                                           GParamSpec *pspec)
+{
+  SpielProviderStreamReader *self = SPIEL_PROVIDER_STREAM_READER (object);
+  SpielProviderStreamReaderPrivate *priv =
+      spiel_provider_stream_reader_get_instance_private (self);
+
+  switch (prop_id)
+    {
+    case PROP_FD:
+      priv->fd = g_value_get_int (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+spiel_provider_stream_reader_class_init (SpielProviderStreamReaderClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = spiel_provider_stream_reader_finalize;
+  object_class->get_property = spiel_provider_stream_reader_get_property;
+  object_class->set_property = spiel_provider_stream_reader_set_property;
+
+  /**
+   * SpielProviderStreamReader:fd:
+   *
+   * File descriptor for pipe
+   *
+   */
+  properties[PROP_FD] =
+      g_param_spec_int ("fd", NULL, NULL, -1, G_MAXINT32, 0,
+                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  g_object_class_install_properties (object_class, N_PROPS, properties);
+}
+
+static void
+spiel_provider_stream_reader_init (SpielProviderStreamReader *self)
+{
+  SpielProviderStreamReaderPrivate *priv =
+      spiel_provider_stream_reader_get_instance_private (self);
+  priv->stream_header_recieved = FALSE;
+  priv->next_chunk_type = SPIEL_PROVIDER_CHUNK_TYPE_NONE;
+}

--- a/libspielprovider/spiel-provider-stream-reader.h
+++ b/libspielprovider/spiel-provider-stream-reader.h
@@ -1,0 +1,52 @@
+/* spiel-provider-stream-reader.h
+ *
+ * Copyright (C) 2024 Eitan Isaacson <eitan@monotonous.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define SPIEL_PROVIDER_TYPE_STREAM_READER                                      \
+  (spiel_provider_stream_reader_get_type ())
+
+G_DECLARE_FINAL_TYPE (SpielProviderStreamReader,
+                      spiel_provider_stream_reader,
+                      SPIEL_PROVIDER,
+                      STREAM_READER,
+                      GObject)
+
+SpielProviderStreamReader *spiel_provider_stream_reader_new (gint fd);
+
+void spiel_provider_stream_reader_close (SpielProviderStreamReader *self);
+
+gboolean spiel_provider_stream_reader_get_stream_header (
+    SpielProviderStreamReader *self);
+
+gboolean spiel_provider_stream_reader_get_audio (
+    SpielProviderStreamReader *self, guint8 **chunk, guint32 *chunk_size);
+
+gboolean
+spiel_provider_stream_reader_get_event (SpielProviderStreamReader *self,
+                                        SpielProviderEventType *event_type,
+                                        guint32 *range_start,
+                                        guint32 *range_end,
+                                        char **mark_name);
+
+G_END_DECLS

--- a/libspielprovider/spiel-provider-stream-writer.c
+++ b/libspielprovider/spiel-provider-stream-writer.c
@@ -1,0 +1,240 @@
+/* spiel-provider-stream-writer.c
+ *
+ * Copyright (C) 2024 Eitan Isaacson <eitan@monotonous.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "spiel-provider.h"
+
+#include "spiel-provider-stream-writer.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+struct _SpielProviderStreamWriter
+{
+  GObject parent_instance;
+};
+
+typedef struct
+{
+  gint fd;
+  gboolean stream_header_sent;
+} SpielProviderStreamWriterPrivate;
+
+G_DEFINE_FINAL_TYPE_WITH_PRIVATE (SpielProviderStreamWriter,
+                                  spiel_provider_stream_writer,
+                                  G_TYPE_OBJECT)
+
+enum
+{
+  PROP_0,
+  PROP_FD,
+  N_PROPS
+};
+
+static GParamSpec *properties[N_PROPS];
+
+/**
+ * spiel_provider_stream_writer_new: (constructor)
+ * @fd: The file descriptor for a pipe
+ *
+ * Creates a new #SpielProviderStreamWriter.
+ *
+ * Returns: The new #SpielProviderStreamWriter.
+ */
+SpielProviderStreamWriter *
+spiel_provider_stream_writer_new (gint fd)
+{
+  if (fcntl (fd, F_GETFD) == -1)
+    {
+      g_warning ("Bad file descriptor");
+      return NULL;
+    }
+
+  return g_object_new (SPIEL_PROVIDER_TYPE_STREAM_WRITER, "fd", fd, NULL);
+}
+
+/**
+ * spiel_provider_stream_writer_close:
+ *
+ * Close the pipe.
+ *
+ */
+void
+spiel_provider_stream_writer_close (SpielProviderStreamWriter *self)
+{
+  SpielProviderStreamWriterPrivate *priv =
+      spiel_provider_stream_writer_get_instance_private (self);
+  close (priv->fd);
+  priv->fd = -1;
+}
+
+/**
+ * spiel_provider_stream_writer_send_stream_header:
+ *
+ * Sends initial stream header
+ *
+ */
+void
+spiel_provider_stream_writer_send_stream_header (
+    SpielProviderStreamWriter *self)
+{
+  SpielProviderStreamWriterPrivate *priv =
+      spiel_provider_stream_writer_get_instance_private (self);
+  SpielProviderStreamHeader header = {
+    .version = SPIEL_PROVIDER_STREAM_PROTOCOL_VERSION
+  };
+  g_assert (!priv->stream_header_sent);
+  write (priv->fd, &header, sizeof (SpielProviderStreamHeader));
+  priv->stream_header_sent = TRUE;
+}
+
+/**
+ * spiel_provider_stream_writer_send_audio:
+ * @chunk: (array length=chunk_size): audio data
+ * @chunk_size: audio chunk size
+ *
+ * Sends audio chunk
+ *
+ */
+void
+spiel_provider_stream_writer_send_audio (SpielProviderStreamWriter *self,
+                                         guint8 *chunk,
+                                         guint32 chunk_size)
+{
+  SpielProviderStreamWriterPrivate *priv =
+      spiel_provider_stream_writer_get_instance_private (self);
+  SpielProviderChunkType chunk_type = SPIEL_PROVIDER_CHUNK_TYPE_AUDIO;
+
+  g_assert (priv->stream_header_sent);
+
+  write (priv->fd, &chunk_type, sizeof (SpielProviderChunkType));
+  write (priv->fd, &chunk_size, sizeof (guint32));
+  write (priv->fd, chunk, chunk_size);
+}
+
+/**
+ * spiel_provider_stream_writer_send_event:
+ *
+ * Sends event
+ *
+ */
+void
+spiel_provider_stream_writer_send_event (SpielProviderStreamWriter *self,
+                                         SpielProviderEventType event_type,
+                                         guint32 range_start,
+                                         guint32 range_end,
+                                         const char *mark_name)
+{
+  SpielProviderStreamWriterPrivate *priv =
+      spiel_provider_stream_writer_get_instance_private (self);
+  SpielProviderChunkType chunk_type = SPIEL_PROVIDER_CHUNK_TYPE_EVENT;
+  SpielProviderEventData event_data = { .event_type = event_type,
+                                        .range_start = range_start,
+                                        .range_end = range_end,
+                                        .mark_name_length =
+                                            g_utf8_strlen (mark_name, -1) };
+  g_assert (priv->stream_header_sent);
+
+  write (priv->fd, &chunk_type, sizeof (SpielProviderChunkType));
+  write (priv->fd, &event_data, sizeof (SpielProviderEventData));
+  if (event_data.mark_name_length)
+    {
+      write (priv->fd, mark_name, event_data.mark_name_length);
+    }
+}
+
+static void
+spiel_provider_stream_writer_finalize (GObject *object)
+{
+  SpielProviderStreamWriter *self = (SpielProviderStreamWriter *) object;
+  SpielProviderStreamWriterPrivate *priv =
+      spiel_provider_stream_writer_get_instance_private (self);
+
+  close (priv->fd);
+  G_OBJECT_CLASS (spiel_provider_stream_writer_parent_class)->finalize (object);
+}
+
+static void
+spiel_provider_stream_writer_get_property (GObject *object,
+                                           guint prop_id,
+                                           GValue *value,
+                                           GParamSpec *pspec)
+{
+  SpielProviderStreamWriter *self = SPIEL_PROVIDER_STREAM_WRITER (object);
+  SpielProviderStreamWriterPrivate *priv =
+      spiel_provider_stream_writer_get_instance_private (self);
+
+  switch (prop_id)
+    {
+    case PROP_FD:
+      g_value_set_int (value, priv->fd);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+spiel_provider_stream_writer_set_property (GObject *object,
+                                           guint prop_id,
+                                           const GValue *value,
+                                           GParamSpec *pspec)
+{
+  SpielProviderStreamWriter *self = SPIEL_PROVIDER_STREAM_WRITER (object);
+  SpielProviderStreamWriterPrivate *priv =
+      spiel_provider_stream_writer_get_instance_private (self);
+
+  switch (prop_id)
+    {
+    case PROP_FD:
+      priv->fd = g_value_get_int (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+spiel_provider_stream_writer_class_init (SpielProviderStreamWriterClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = spiel_provider_stream_writer_finalize;
+  object_class->get_property = spiel_provider_stream_writer_get_property;
+  object_class->set_property = spiel_provider_stream_writer_set_property;
+
+  /**
+   * SpielProviderStreamWriter:fd:
+   *
+   * File descriptor for pipe
+   *
+   */
+  properties[PROP_FD] =
+      g_param_spec_int ("fd", NULL, NULL, -1, G_MAXINT32, 0,
+                        G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+  g_object_class_install_properties (object_class, N_PROPS, properties);
+}
+
+static void
+spiel_provider_stream_writer_init (SpielProviderStreamWriter *self)
+{
+  SpielProviderStreamWriterPrivate *priv =
+      spiel_provider_stream_writer_get_instance_private (self);
+  priv->stream_header_sent = FALSE;
+}

--- a/libspielprovider/spiel-provider-stream-writer.h
+++ b/libspielprovider/spiel-provider-stream-writer.h
@@ -1,0 +1,52 @@
+/* spiel-provider-stream-writer.h
+ *
+ * Copyright (C) 2024 Eitan Isaacson <eitan@monotonous.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define SPIEL_PROVIDER_TYPE_STREAM_WRITER                                      \
+  (spiel_provider_stream_writer_get_type ())
+
+G_DECLARE_FINAL_TYPE (SpielProviderStreamWriter,
+                      spiel_provider_stream_writer,
+                      SPIEL_PROVIDER,
+                      STREAM_WRITER,
+                      GObject)
+
+SpielProviderStreamWriter *spiel_provider_stream_writer_new (gint fd);
+
+void spiel_provider_stream_writer_close (SpielProviderStreamWriter *self);
+
+void spiel_provider_stream_writer_send_stream_header (
+    SpielProviderStreamWriter *self);
+
+void spiel_provider_stream_writer_send_audio (SpielProviderStreamWriter *self,
+                                              guint8 *chunk,
+                                              guint32 chunk_size);
+
+void spiel_provider_stream_writer_send_event (SpielProviderStreamWriter *self,
+                                              SpielProviderEventType event_type,
+                                              guint32 range_start,
+                                              guint32 range_end,
+                                              const char *mark_name);
+
+G_END_DECLS

--- a/libspielprovider/spiel-provider-version.h.in
+++ b/libspielprovider/spiel-provider-version.h.in
@@ -1,0 +1,78 @@
+
+#pragma once
+
+#if !defined(SPIEL_PROVIDER_INSIDE) && !defined(SPIEL_PROVIDER_COMPILATION)
+#error "Only <spiel-provider.h> can be included directly."
+#endif
+
+/**
+ * SECTION:spiel-providerversion
+ * @short_description: spiel-provider version checking
+ *
+ * spiel-provider provides macros to check the version of the library
+ * at compile-time
+ */
+
+/**
+ * SPIEL_PROVIDER_MAJOR_VERSION:
+ *
+ * spiel-provider major version component (e.g. 1 if %SPIEL_PROVIDER_VERSION is 1.2.3)
+ */
+#define SPIEL_PROVIDER_MAJOR_VERSION (@MAJOR_VERSION @)
+
+/**
+ * SPIEL_PROVIDER_MINOR_VERSION:
+ *
+ * spiel-provider minor version component (e.g. 2 if %SPIEL_PROVIDER_VERSION is 1.2.3)
+ */
+#define SPIEL_PROVIDER_MINOR_VERSION (@MINOR_VERSION @)
+
+/**
+ * SPIEL_PROVIDER_MICRO_VERSION:
+ *
+ * spiel-provider micro version component (e.g. 3 if %SPIEL_PROVIDER_VERSION is 1.2.3)
+ */
+#define SPIEL_PROVIDER_MICRO_VERSION (@MICRO_VERSION @)
+
+/**
+ * SPIEL_PROVIDER_VERSION
+ *
+ * spiel-provider version.
+ */
+#define SPIEL_PROVIDER_VERSION (@VERSION @)
+
+/**
+ * SPIEL_PROVIDER_VERSION_S:
+ *
+ * spiel-provider version, encoded as a string, useful for printing and
+ * concatenation.
+ */
+#define SPIEL_PROVIDER_VERSION_S "@VERSION@"
+
+#define SPIEL_PROVIDER_ENCODE_VERSION(major, minor, micro)                              \
+  ((major) << 24 | (minor) << 16 | (micro) << 8)
+
+/**
+ * SPIEL_PROVIDER_VERSION_HEX:
+ *
+ * spiel-provider version, encoded as an hexadecimal number, useful for
+ * integer comparisons.
+ */
+#define SPIEL_PROVIDER_VERSION_HEX                                                      \
+  (SPIEL_PROVIDER_ENCODE_VERSION (SPIEL_PROVIDER_MAJOR_VERSION, SPIEL_PROVIDER_MINOR_VERSION,             \
+                         SPIEL_PROVIDER_MICRO_VERSION))
+
+/**
+ * SPIEL_PROVIDER_CHECK_VERSION:
+ * @major: required major version
+ * @minor: required minor version
+ * @micro: required micro version
+ *
+ * Compile-time version checking. Evaluates to %TRUE if the version
+ * of spiel-provider is greater than the required one.
+ */
+#define SPIEL_PROVIDER_CHECK_VERSION(major, minor, micro)                               \
+  (SPIEL_PROVIDER_MAJOR_VERSION > (major) ||                                            \
+   (SPIEL_PROVIDER_MAJOR_VERSION == (major) && SPIEL_PROVIDER_MINOR_VERSION > (minor)) ||        \
+   (SPIEL_PROVIDER_MAJOR_VERSION == (major) && SPIEL_PROVIDER_MINOR_VERSION == (minor) &&        \
+    SPIEL_PROVIDER_MICRO_VERSION >= (micro)))

--- a/libspielprovider/spiel-provider.h
+++ b/libspielprovider/spiel-provider.h
@@ -1,0 +1,32 @@
+/* spiel-provider.h
+ *
+ * Copyright (C) 2024 Eitan Isaacson <eitan@monotonous.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+#define SPIEL_PROVIDER_INSIDE
+#include "spiel-provider-common.h"
+#include "spiel-provider-stream-reader.h"
+#include "spiel-provider-stream-writer.h"
+#undef SPIEL_PROVIDER_INSIDE
+
+G_END_DECLS

--- a/meson.build
+++ b/meson.build
@@ -79,12 +79,14 @@ foreach arg: test_c_args
 endforeach
 add_project_arguments(project_c_args, language: 'c')
 
-subdir('libspiel')
+if get_option('libspiel')
+  subdir('libspiel')
+endif
 
 if get_option('docs')
   subdir('doc')
 endif
 
-if get_option('tests')
+if get_option('tests') and get_option('libspiel')
   subdir('tests')
 endif

--- a/meson.build
+++ b/meson.build
@@ -79,6 +79,10 @@ foreach arg: test_c_args
 endforeach
 add_project_arguments(project_c_args, language: 'c')
 
+if get_option('libspielprovider')
+  subdir('libspielprovider')
+endif
+
 if get_option('libspiel')
   subdir('libspiel')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
+option('libspiel', type: 'boolean', value: true, description: 'Enable libspiel')
 option('tests', type: 'boolean', value: true, description: 'Enable tests')
 option('docs', type: 'boolean', value: true, description: 'Enable docs')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('libspiel', type: 'boolean', value: true, description: 'Enable libspiel')
+option('libspielprovider', type: 'boolean', value: true, description: 'Enable libspielprovider')
 option('tests', type: 'boolean', value: true, description: 'Enable tests')
 option('docs', type: 'boolean', value: true, description: 'Enable docs')

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -52,7 +52,7 @@ class BaseSpielTest(unittest.TestCase):
 
     def setUp(self):
         self.mock_service = self.mock_iface("org.mock.Speech.Provider")
-        self.mock_service.SetAutoStep(True)
+        self.mock_service.SetInfinite(False)
         self.mock_service.FlushTasks()
 
     def tearDown(self):
@@ -190,6 +190,14 @@ class BaseSpielTest(unittest.TestCase):
             os.environ["TEST_SERVICE_DIR"], f"{name}{os.path.extsep}service"
         )
         os.rename(src, dest)
+
+    def get_voice(self, synth, provider_name, voice_id):
+        for v in synth.props.voices:
+            if (
+                v.props.provider_name == provider_name
+                and v.props.identifier == voice_id
+            ):
+                return v
 
 
 def test_main():

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -20,7 +20,8 @@ tests = ['test_speak.py',
          'test_voices.py',
          'test_settings.py',
          'test_voice_selection.py',
-         'test_errors.py']
+         'test_errors.py',
+         'test_audio.py']
 
 newer_dbus = dependency('dbus-1', version : '>=1.14.4', required : false)
 if newer_dbus.found()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,12 +14,14 @@ dbus_run_session = find_program('dbus-run-session', required : false)
 python = python_module.find_installation(
   'python3', required : false, modules: 'tap')
 
-tests = ['test_speak.py',
+tests = [
+#         'test_speak.py',
          'test_types.py',
          'test_voices.py',
          'test_settings.py',
-         'test_voice_selection.py',
-         'test_errors.py']
+#         'test_voice_selection.py',
+#         'test_errors.py'
+]
 
 newer_dbus = dependency('dbus-1', version : '>=1.14.4', required : false)
 if newer_dbus.found()
@@ -57,13 +59,13 @@ if dbus_run_session.found() and python.found()
     )
   endforeach
 
-test('test-simple-speak', dbus_run_session,
-      args : [
-        '--config-file=@0@'.format(join_paths(meson.current_build_dir(), 'test-bus.conf')),
-        '--', test_simple_speak
-        ],
-      env : test_env
-    )
+# test('test-simple-speak', dbus_run_session,
+#       args : [
+#         '--config-file=@0@'.format(join_paths(meson.current_build_dir(), 'test-bus.conf')),
+#         '--', test_simple_speak
+#         ],
+#       env : test_env
+#     )
 endif
 
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,20 +8,19 @@ test_env.set('TEST_SERVICE_DIR', service_dir)
 test_env.set('TEST_DISCARDED_SERVICE_DIR', join_paths(meson.current_build_dir(), 'discarded_services'))
 test_env.set('GSETTINGS_SCHEMA_DIR', join_paths(meson.project_build_root(), 'libspiel'))
 test_env.set('GSETTINGS_BACKEND', 'memory')
+test_env.set('SPIEL_TEST', '1')
 
 python_module = import('python')
 dbus_run_session = find_program('dbus-run-session', required : false)
 python = python_module.find_installation(
   'python3', required : false, modules: 'tap')
 
-tests = [
-#         'test_speak.py',
+tests = ['test_speak.py',
          'test_types.py',
          'test_voices.py',
          'test_settings.py',
-#         'test_voice_selection.py',
-#         'test_errors.py'
-]
+         'test_voice_selection.py',
+         'test_errors.py']
 
 newer_dbus = dependency('dbus-1', version : '>=1.14.4', required : false)
 if newer_dbus.found()
@@ -59,13 +58,13 @@ if dbus_run_session.found() and python.found()
     )
   endforeach
 
-# test('test-simple-speak', dbus_run_session,
-#       args : [
-#         '--config-file=@0@'.format(join_paths(meson.current_build_dir(), 'test-bus.conf')),
-#         '--', test_simple_speak
-#         ],
-#       env : test_env
-#     )
+test('test-simple-speak', dbus_run_session,
+      args : [
+        '--config-file=@0@'.format(join_paths(meson.current_build_dir(), 'test-bus.conf')),
+        '--', test_simple_speak
+        ],
+      env : test_env
+    )
 endif
 
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,8 +1,12 @@
 service_dir = join_paths(meson.current_build_dir(), 'services')
 
 test_env = environment()
-test_env.set('GI_TYPELIB_PATH', join_paths(meson.project_build_root(), 'libspiel'))
-test_env.set('LD_LIBRARY_PATH', join_paths(meson.project_build_root(), 'libspiel'))
+test_env.prepend('GI_TYPELIB_PATH',
+  join_paths(meson.project_build_root(), 'libspiel'),
+  join_paths(meson.project_build_root(), 'libspielprovider'), separator: ':')
+test_env.prepend('LD_LIBRARY_PATH',
+  join_paths(meson.project_build_root(), 'libspiel'),
+  join_paths(meson.project_build_root(), 'libspielprovider'), separator: ':')
 test_env.set('G_DEBUG', 'fatal-warnings')
 test_env.set('TEST_SERVICE_DIR', service_dir)
 test_env.set('TEST_DISCARDED_SERVICE_DIR', join_paths(meson.current_build_dir(), 'discarded_services'))
@@ -21,7 +25,8 @@ tests = ['test_speak.py',
          'test_settings.py',
          'test_voice_selection.py',
          'test_errors.py',
-         'test_audio.py']
+         'test_audio.py',
+         'test_provider_lib.py']
 
 newer_dbus = dependency('dbus-1', version : '>=1.14.4', required : false)
 if newer_dbus.found()

--- a/tests/services/mock_speech_provider.py
+++ b/tests/services/mock_speech_provider.py
@@ -17,11 +17,13 @@ VOICES = {
     "mock": [
         {
             "name": "Chinese (Cantonese)",
+            "output_format": "audio/x-raw,format=S16LE,channels=1,rate=22050",
             "identifier": "sit/yue",
             "languages": ["yue", "zh-yue", "zh"],
         },
         {
             "name": "Armenian (East Armenia)",
+            "output_format": "audio/x-raw,format=S16LE,channels=1,rate=22050",
             "identifier": "ine/hy",
             "languages": ["hy", "hy-arevela"],
         },
@@ -29,26 +31,31 @@ VOICES = {
     "mock2": [
         {
             "name": "Armenian (West Armenia)",
+            "output_format": "audio/x-raw,format=S16LE,channels=1,rate=22050",
             "identifier": "ine/hyw",
             "languages": ["hyw", "hy-arevmda", "hy"],
         },
         {
             "name": "English (Scotland)",
+            "output_format": "nuthin",
             "identifier": "gmw/en-GB-scotland",
             "languages": ["en-gb-scotland", "en"],
         },
         {
             "name": "English (Lancaster)",
+            "output_format": "audio/x-raw,format=S16LE,channels=1,rate=22050",
             "identifier": "gmw/en-GB-x-gbclan",
             "languages": ["en-gb-x-gbclan", "en-gb", "en"],
         },
         {
             "name": "English (America)",
+            "output_format": "audio/x-raw,format=S16LE,channels=1,rate=22050",
             "identifier": "gmw/en-US",
             "languages": ["en-us", "en"],
         },
         {
             "name": "English (Great Britain)",
+            "output_format": "audio/x-raw,format=S16LE,channels=1,rate=22050",
             "identifier": "gmw/en",
             "languages": ["en-gb", "en"],
         },
@@ -56,6 +63,7 @@ VOICES = {
     "mock3": [
         {
             "name": "Uzbek",
+            "output_format": "audio/x-raw,format=S16LE,channels=1,rate=22050",
             "identifier": "trk/uz",
             "languages": ["uz"],
         },
@@ -75,12 +83,15 @@ class SomeObject(dbus.service.Object):
     @dbus.service.method(
         "org.freedesktop.Speech.Provider",
         in_signature="",
-        out_signature="a(ssas)",
+        out_signature="a(sssas)",
     )
     def GetVoices(self):
         if AUTOEXIT:
             GLib.idle_add(self.byebye)
-        return [(v["name"], v["identifier"], v["languages"]) for v in self._voices]
+        return [
+            (v["name"], v["identifier"], v["output_format"], v["languages"])
+            for v in self._voices
+        ]
 
     @dbus.service.signal("org.freedesktop.Speech.Provider")
     def VoicesChanged(self):
@@ -117,7 +128,12 @@ class SomeObject(dbus.service.Object):
     )
     def AddVoice(self, name, identifier, languages):
         self._voices.append(
-            {"name": name, "identifier": identifier, "languages": languages}
+            {
+                "name": name,
+                "identifier": identifier,
+                "output_format": "audio/x-raw,format=S16LE,channels=1,rate=22050",
+                "languages": languages,
+            }
         )
         GLib.idle_add(self.VoicesChanged)
 

--- a/tests/test-simple-speak.c
+++ b/tests/test-simple-speak.c
@@ -2,9 +2,10 @@
 
 static GMainLoop *main_loop;
 static uint speaking_change_count = 0;
+static SpielSpeaker *speaker = NULL;
 
 static void
-speaking_cb (SpielSpeaker *speaker, GParamSpec *pspec, gpointer user_data)
+speaking_cb (SpielSpeaker *_speaker, GParamSpec *pspec, gpointer user_data)
 {
   gboolean speaking = FALSE;
   speaking_change_count++;
@@ -12,7 +13,6 @@ speaking_cb (SpielSpeaker *speaker, GParamSpec *pspec, gpointer user_data)
 
   if (!speaking)
     {
-      g_object_unref (speaker);
       g_assert_cmpuint (speaking_change_count, ==, 2);
       g_main_loop_quit (main_loop);
     }
@@ -22,8 +22,9 @@ static void
 speaker_new_cb (GObject *source, GAsyncResult *result, gpointer user_data)
 {
   GError *err = NULL;
-  SpielSpeaker *speaker = spiel_speaker_new_finish (result, &err);
   SpielUtterance *utterance = spiel_utterance_new ("hello world");
+
+  speaker = spiel_speaker_new_finish (result, &err);
   g_assert_no_error (err);
   if (err)
     g_error_free (err);
@@ -47,6 +48,7 @@ test_speak (void)
   main_loop = g_main_loop_new (NULL, FALSE);
   spiel_speaker_new (NULL, speaker_new_cb, NULL);
   g_main_loop_run (main_loop);
+  g_object_unref (speaker);
 }
 
 gint

--- a/tests/test-simple-speak.c
+++ b/tests/test-simple-speak.c
@@ -33,7 +33,7 @@ speaker_new_cb (GObject *source, GAsyncResult *result, gpointer user_data)
   g_assert (utterance != NULL);
 
   // prevents mock3 from being used
-  spiel_utterance_set_language (utterance, "en");
+  spiel_utterance_set_language (utterance, "hy");
 
   spiel_speaker_speak (speaker, utterance);
   g_object_unref (utterance);

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -48,6 +48,10 @@ class TestSpeak(BaseSpielTest):
 
         utterance = Spiel.Utterance(text="hello world, how are you?")
         utterance.props.volume = 1
+        utterance.props.voice = self.get_voice(
+            speechSynthesis, "org.mock2.Speech.Provider", "gmw/en-US"
+        )
+
         speechSynthesis.speak(utterance)
 
         loop.run()
@@ -67,6 +71,9 @@ class TestSpeak(BaseSpielTest):
 
         utterance = Spiel.Utterance(text="hello world, how are you?")
         utterance.props.volume = 0.5
+        utterance.props.voice = self.get_voice(
+            speechSynthesis, "org.mock2.Speech.Provider", "gmw/en-US"
+        )
         speechSynthesis.speak(utterance)
 
         loop.run()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,76 @@
+from _common import *
+
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst
+
+Gst.init(None)
+
+
+class TestSpeak(BaseSpielTest):
+    def _setup_custom_sink(self):
+        bin = Gst.Bin.new("bin")
+        level = Gst.ElementFactory.make("level", "level")
+        bin.add(level)
+        sink = Gst.ElementFactory.make("fakesink", "sink")
+        bin.add(sink)
+        level.link(sink)
+
+        level.set_property("post-messages", True)
+        # level.set_property("interval", 100)
+        sink.set_property("sync", True)
+
+        pad = level.get_static_pad("sink")
+        ghostpad = Gst.GhostPad.new("sink", pad)
+        bin.add_pad(ghostpad)
+
+        speechSynthesis = Spiel.Speaker.new_sync(None)
+        speechSynthesis.props.sink = bin
+
+        pipeline = bin.get_parent()
+        bus = pipeline.get_bus()
+
+        return speechSynthesis, bus
+
+    def test_max_volume(self):
+        loop = GLib.MainLoop()
+
+        def _on_message(bus, message):
+            info = message.get_structure()
+            if info.get_name() == "level":
+                self.assertGreater(info.get_value("rms")[0], -5)
+                loop.quit()
+
+        speechSynthesis, bus = self._setup_custom_sink()
+
+        bus.connect("message::element", _on_message)
+
+        utterance = Spiel.Utterance(text="hello world, how are you?")
+        utterance.props.volume = 1
+        speechSynthesis.speak(utterance)
+
+        loop.run()
+
+    def test_half_volume(self):
+        loop = GLib.MainLoop()
+
+        def _on_message(bus, message):
+            info = message.get_structure()
+            if info.get_name() == "level":
+                self.assertLess(info.get_value("rms")[0], -5)
+                loop.quit()
+
+        speechSynthesis, bus = self._setup_custom_sink()
+
+        bus.connect("message::element", _on_message)
+
+        utterance = Spiel.Utterance(text="hello world, how are you?")
+        utterance.props.volume = 0.5
+        speechSynthesis.speak(utterance)
+
+        loop.run()
+
+
+if __name__ == "__main__":
+    test_main()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -12,6 +12,7 @@ class TestSpeak(BaseSpielTest):
         def _started_cb(synth, utt):
             actual_events.append("utterance-started")
             self.assertEqual(utt, utterance)
+            self.mock_service.Die()
 
         def _error_cb(synth, utt, err):
             self.assertTrue(
@@ -29,7 +30,7 @@ class TestSpeak(BaseSpielTest):
 
         actual_events = []
 
-        self.mock_service.DieOnSpeak()
+        self.mock_service.SetInfinite(True)
         speechSynthesis = Spiel.Speaker.new_sync(None)
         self.assertFalse(speechSynthesis.props.speaking)
         self.assertFalse(speechSynthesis.props.paused)
@@ -38,6 +39,60 @@ class TestSpeak(BaseSpielTest):
         speechSynthesis.connect("utterance-error", _error_cb)
         utterance = Spiel.Utterance(text="hello world, how are you?")
         speechSynthesis.speak(utterance)
+
+        loop = GLib.MainLoop()
+        loop.run()
+
+    def test_bad_voice(self):
+        def _notify_speaking_cb(synth, val):
+            actual_events.append("notify:speaking=%s" % synth.props.speaking)
+            if not synth.props.speaking:
+                self.assertEqual(actual_events, expected_events)
+                loop.quit()
+
+        def _started_cb(synth, utt):
+            actual_events.append("utterance-started")
+
+        def _finished_cb(synth, utt):
+            actual_events.append("utterance-finished")
+
+        def _error_cb(synth, utt, err):
+            self.assertTrue(
+                err.matches(Spiel.error_quark(), Spiel.Error.MISCONFIGURED_VOICE)
+            )
+            actual_events.append("utterance-error")
+
+        expected_events = [
+            "notify:speaking=True",
+            "utterance-started",
+            "utterance-finished",
+            "utterance-error",
+            "utterance-started",
+            "utterance-finished",
+            "notify:speaking=False",
+        ]
+
+        actual_events = []
+
+        self.mock_service.SetInfinite(True)
+        speechSynthesis = Spiel.Speaker.new_sync(None)
+        self.assertFalse(speechSynthesis.props.speaking)
+        self.assertFalse(speechSynthesis.props.paused)
+        speechSynthesis.connect("notify::speaking", _notify_speaking_cb)
+        speechSynthesis.connect("utterance-started", _started_cb)
+        speechSynthesis.connect("utterance-error", _error_cb)
+        speechSynthesis.connect("utterance-finished", _finished_cb)
+
+        for provider_name, voice_id in [
+            ("org.mock2.Speech.Provider", "ine/hyw"),
+            ("org.mock2.Speech.Provider", "gmw/en-GB-scotland"),
+            ("org.mock2.Speech.Provider", "gmw/en-GB-x-gbclan"),
+        ]:
+            utterance = Spiel.Utterance(text="hello world, how are you?")
+            utterance.props.voice = self.get_voice(
+                speechSynthesis, provider_name, voice_id
+            )
+            speechSynthesis.speak(utterance)
 
         loop = GLib.MainLoop()
         loop.run()

--- a/tests/test_provider_lib.py
+++ b/tests/test_provider_lib.py
@@ -1,0 +1,59 @@
+import unittest, os
+import gi
+
+gi.require_version("SpielProvider", "0.1")
+from gi.repository import SpielProvider
+
+from _common import test_main
+
+
+class TestSpeak(unittest.TestCase):
+    def test_bad_header(self):
+        r, w = os.pipe2(os.O_NONBLOCK)
+
+        sr = SpielProvider.StreamReader.new(r)
+
+        ww = os.fdopen(w, "w")
+        ww.write("boop")
+
+        success = sr.get_stream_header()
+        self.assertFalse(success)
+
+    def test_simple(self):
+        r, w = os.pipe2(os.O_NONBLOCK)
+
+        sw = SpielProvider.StreamWriter.new(w)
+        sr = SpielProvider.StreamReader.new(r)
+
+        sw.send_stream_header()
+        sw.send_audio(b"foo")
+        sw.send_event(2, 20, 24, "bar")
+
+        success = sr.get_stream_header()
+        self.assertTrue(success)
+
+        # Event is not next chunk, so return empty event
+        event_type, range_start, range_end, mark_name = sr.get_event()
+        self.assertEqual(event_type, SpielProvider.EventType.NONE)
+        self.assertEqual(range_start, 0)
+        self.assertEqual(range_end, 0)
+        self.assertEqual(mark_name, None)
+
+        # Get audio chunk
+        audio = sr.get_audio()
+        self.assertEqual(audio, b"foo")
+
+        # Audio is not next chunk, return empty buffer
+        audio = sr.get_audio()
+        self.assertEqual(audio, b"")
+
+        # Get event chunk
+        event_type, range_start, range_end, mark_name = sr.get_event()
+        self.assertEqual(event_type, SpielProvider.EventType.SENTENCE)
+        self.assertEqual(range_start, 20)
+        self.assertEqual(range_end, 24)
+        self.assertEqual(mark_name, "bar")
+
+
+if __name__ == "__main__":
+    test_main()

--- a/tests/test_speak.py
+++ b/tests/test_speak.py
@@ -29,11 +29,11 @@ class TestSpeak(BaseSpielTest):
         expected_events = [
             "notify:speaking=True",
             "utterance-started",
-            # "range-started",
-            # "range-started",
-            # "range-started",
-            # "range-started",
-            # "range-started",
+            "range-started",
+            "range-started",
+            "range-started",
+            "range-started",
+            "range-started",
             "utterance-finished",
             "notify:speaking=False",
         ]
@@ -47,7 +47,12 @@ class TestSpeak(BaseSpielTest):
         speechSynthesis.connect("utterance-started", _started_cb)
         speechSynthesis.connect("range-started", _range_started_cb)
         speechSynthesis.connect("utterance-finished", _finished_cb)
+
         utterance = Spiel.Utterance(text="hello world, how are you?")
+        utterance.props.voice = self.get_voice(
+            speechSynthesis, "org.mock2.Speech.Provider", "gmw/en-US"
+        )
+
         speechSynthesis.speak(utterance)
 
         loop = GLib.MainLoop()

--- a/tests/test_speak.py
+++ b/tests/test_speak.py
@@ -29,11 +29,11 @@ class TestSpeak(BaseSpielTest):
         expected_events = [
             "notify:speaking=True",
             "utterance-started",
-            "range-started",
-            "range-started",
-            "range-started",
-            "range-started",
-            "range-started",
+            # "range-started",
+            # "range-started",
+            # "range-started",
+            # "range-started",
+            # "range-started",
             "utterance-finished",
             "notify:speaking=False",
         ]
@@ -103,10 +103,10 @@ class TestSpeak(BaseSpielTest):
             if speechSynthesis.props.paused:
                 synth.resume()
             else:
-                self.mock_service.SetAutoStep(True)
+                synth.cancel()
 
-        def _finished_cb(synth, utt):
-            actual_events.append("utterance-finished")
+        def _canceled_cb(synth, utt):
+            actual_events.append("utterance-canceled")
             self.assertFalse(speechSynthesis.props.paused)
             self.assertEqual(
                 actual_events,
@@ -114,18 +114,18 @@ class TestSpeak(BaseSpielTest):
                     "utterance-started",
                     "notify:paused=True",
                     "notify:paused=False",
-                    "utterance-finished",
+                    "utterance-canceled",
                 ],
             )
             loop.quit()
 
         actual_events = []
 
-        self.mock_service.SetAutoStep(False)
+        self.mock_service.SetInfinite(True)
         speechSynthesis = Spiel.Speaker.new_sync(None)
         speechSynthesis.connect("utterance-started", _started_cb)
         speechSynthesis.connect("notify::paused", _notify_paused_cb)
-        speechSynthesis.connect("utterance-finished", _finished_cb)
+        speechSynthesis.connect("utterance-canceled", _canceled_cb)
         utterance = Spiel.Utterance(text="hello world, how are you?")
         speechSynthesis.speak(utterance)
 
@@ -157,7 +157,7 @@ class TestSpeak(BaseSpielTest):
         def _canceled_cb(synth, utt):
             actual_events.append("canceled '%s'" % utt.props.text)
 
-        self.mock_service.SetAutoStep(False)
+        self.mock_service.SetInfinite(True)
         speechSynthesis = Spiel.Speaker.new_sync(None)
         speechSynthesis.connect("notify::speaking", _notify_speaking_cb)
         speechSynthesis.connect("utterance-started", _started_cb)
@@ -201,7 +201,7 @@ class TestSpeak(BaseSpielTest):
 
         actual_events = []
 
-        self.mock_service.SetAutoStep(False)
+        self.mock_service.SetInfinite(True)
         speechSynthesis = Spiel.Speaker.new_sync(None)
         speechSynthesis.connect("utterance-started", _started_cb)
         speechSynthesis.connect("notify::speaking", _notify_speaking_cb)

--- a/tests/test_voice_selection.py
+++ b/tests/test_voice_selection.py
@@ -41,24 +41,14 @@ class TestSpeak(BaseSpielTest):
         self.assertEqual(utterance.props.voice.props.name, "Armenian (East Armenia)")
 
     def _test_speak_with_voice(self, speechSynthesis, provider_name, voice_id):
-        voice = None
-        for v in speechSynthesis.props.voices:
-            if (
-                v.props.provider_name == provider_name
-                and v.props.identifier == voice_id
-            ):
-                voice = v
+        voice = self.get_voice(speechSynthesis, provider_name, voice_id)
 
         utterance = Spiel.Utterance(text="hello world, how are you?", voice=voice)
-        self.mock_iface(provider_name).SetAutoStep(False)
         self.wait_for_speaking_changed(
             speechSynthesis, lambda: speechSynthesis.speak(utterance)
         )
         args = self.mock_iface(provider_name).GetLastSpeakArguments()
         self.assertEqual(str(args[2]), voice_id)
-        self.wait_for_speaking_changed(
-            speechSynthesis, lambda: self.mock_iface(provider_name).SetAutoStep(True)
-        )
 
     def test_speak_with_voice_sync(self):
         speechSynthesis = Spiel.Speaker.new_sync(None)


### PR DESCRIPTION
This branch changes the spec and client library to enable the client to stream the audio to the device directly. Instead of providers writing to the audio output device they write to a pipe. The client reads from the pipe and does the audio output itself.