### PR TITLE
spiel-collect-providers: fix NULL-pointer dereference

### DIFF
--- a/libspiel/spiel-collect-providers.c
+++ b/libspiel/spiel-collect-providers.c
@@ -351,7 +351,7 @@ spiel_collect_providers_sync (GDBusConnection *connection,
           connection, "org.freedesktop.DBus", "/org/freedesktop/DBus",
           "org.freedesktop.DBus", *method, NULL, NULL, G_DBUS_CALL_FLAGS_NONE,
           -1, NULL, error);
-      if (*error)
+      if (error && *error)
         {
           g_warning ("Error calling list (%s): %s\n", *method,
                      (*error)->message);

--- a/libspiel/spiel-registry.c
+++ b/libspiel/spiel-registry.c
@@ -438,7 +438,7 @@ initable_init (GInitable *initable, GCancellable *cancellable, GError **error)
 
   providers = spiel_collect_providers_sync (bus, cancellable, error);
 
-  if (*error != NULL)
+  if (error && *error != NULL)
     {
       g_warning ("Error retrieving providers: %s\n", (*error)->message);
       return FALSE;

--- a/libspiel/spiel-speaker.c
+++ b/libspiel/spiel-speaker.c
@@ -541,15 +541,18 @@ initable_init (GInitable *initable, GCancellable *cancellable, GError **error)
 {
   SpielSpeaker *self = SPIEL_SPEAKER (initable);
   SpielSpeakerPrivate *priv = spiel_speaker_get_instance_private (self);
-  priv->registry = spiel_registry_get_sync (cancellable, error);
-  if (*error == NULL)
+  GError *err = NULL;
+
+  priv->registry = spiel_registry_get_sync (cancellable, &err);
+  if (err == NULL)
     {
-      _setup_pipeline (self, error);
+      _setup_pipeline (self, &err);
     }
 
-  if (*error)
+  if (err != NULL)
     {
       g_warning ("Error initializing speaker: %s\n", (*error)->message);
+      g_propagate_error (error, err);
       return FALSE;
     }
 


### PR DESCRIPTION
A `GError **` may be a pointer to NULL or NULL itself, so check before dereferencing.