### PR TITLE
build: include generated headers in library

### DIFF
--- a/libspeechprovider/meson.build
+++ b/libspeechprovider/meson.build
@@ -58,7 +58,7 @@ speech_provider_deps = [
 ]
 
 speech_provider_lib = shared_library('speech-provider-' + api_version,
-  speech_provider_sources,
+  [speech_provider_sources, speech_provider_lib_generated],
   dependencies: speech_provider_deps,
   install: true,
 )


### PR DESCRIPTION
In addition to the dependency object, the generated headers need to be included as sources, since some are not installed.

closes #35