### PR TITLE
Various cleanups, docs and safety checks

### DIFF
--- a/libspeechprovider/meson.build
+++ b/libspeechprovider/meson.build
@@ -54,7 +54,7 @@ speech_provider_lib_generated = [
 ]
 
 speech_provider_deps = [
-  dependency('gobject-2.0'),
+  dependency('gobject-2.0', version: glib_version),
 ]
 
 speech_provider_lib = shared_library('speech-provider-' + api_version,

--- a/libspeechprovider/speech-provider-stream-reader.c
+++ b/libspeechprovider/speech-provider-stream-reader.c
@@ -24,6 +24,13 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+/**
+ * SpeechProviderStreamReader:
+ *
+ * A provider audio stream reader.
+ *
+ * Since: 1.0
+ */
 struct _SpeechProviderStreamReader
 {
   GObject parent_instance;
@@ -53,9 +60,11 @@ static GParamSpec *properties[N_PROPS];
  * speech_provider_stream_reader_new: (constructor)
  * @fd: The file descriptor for a pipe
  *
- * Creates a new #SpeechProviderStreamReader.
+ * Creates a new [class@SpeechProvider.StreamReader].
  *
- * Returns: The new #SpeechProviderStreamReader.
+ * Returns: (transfer full): The new `SpeechProviderStreamReader`.
+ *
+ * Since: 1.0
  */
 SpeechProviderStreamReader *
 speech_provider_stream_reader_new (gint fd)
@@ -71,9 +80,11 @@ speech_provider_stream_reader_new (gint fd)
 
 /**
  * speech_provider_stream_reader_close:
+ * @self: `SpeechProviderStreamReader`
  *
  * Close the pipe.
  *
+ * Since: 1.0
  */
 void
 speech_provider_stream_reader_close (SpeechProviderStreamReader *self)
@@ -89,10 +100,13 @@ speech_provider_stream_reader_close (SpeechProviderStreamReader *self)
 
 /**
  * speech_provider_stream_reader_get_stream_header:
+ * @self: `SpeechProviderStreamReader`
  *
  * Retrieves stream header.
  *
  * Returns: %TRUE if header successfully received.
+ *
+ * Since: 1.0
  */
 gboolean
 speech_provider_stream_reader_get_stream_header (
@@ -124,14 +138,17 @@ _get_next_chunk_type (SpeechProviderStreamReader *self)
 }
 
 /**
- * speech_provider_stream_reader_get_audio:
- * @chunk: (out) (array length=chunk_size) (transfer full): Location to
- *        store audio data
- * @chunk_size: (out): Location to store size of chunk
+ * speech_provider_stream_reader_get_audio: (skip)
+ * @self: `SpeechProviderStreamReader`
+ * @chunk: (out) (array length=chunk_size) (transfer full) (not nullable):
+ *        Location to store audio data
+ * @chunk_size: (out) (not nullable): Location to store size of chunk
  *
  * Retrieves audio data
  *
- * Returns: (skip): %TRUE if the call succeeds.
+ * Returns: %TRUE if the call succeeds.
+ *
+ * Since: 1.0
  */
 gboolean
 speech_provider_stream_reader_get_audio (SpeechProviderStreamReader *self,
@@ -162,15 +179,18 @@ speech_provider_stream_reader_get_audio (SpeechProviderStreamReader *self,
 }
 
 /**
- * speech_provider_stream_reader_get_event:
- * @event_type: (out): type of event
- * @range_start: (out): text range start
- * @range_end: (out): text range end
- * @mark_name: (out): mark name
+ * speech_provider_stream_reader_get_event: (skip)
+ * @self: a `SpeechProviderStreamReader`
+ * @event_type: (out) (not nullable): type of event
+ * @range_start: (out) (not nullable): text range start
+ * @range_end: (out) (not nullable): text range end
+ * @mark_name: (out) (not nullable): mark name
  *
  * Retrieves event data
  *
- * Returns: (skip): %TRUE if the call succeeds.
+ * Returns: %TRUE if the call succeeds.
+ *
+ * Since: 1.0
  */
 gboolean
 speech_provider_stream_reader_get_event (SpeechProviderStreamReader *self,
@@ -262,8 +282,9 @@ speech_provider_stream_reader_class_init (
   /**
    * SpeechProviderStreamReader:fd:
    *
-   * File descriptor for pipe
+   * File descriptor for pipe.
    *
+   * Since: 1.0
    */
   properties[PROP_FD] =
       g_param_spec_int ("fd", NULL, NULL, -1, G_MAXINT32, 0,

--- a/libspeechprovider/speech-provider-stream-reader.c
+++ b/libspeechprovider/speech-provider-stream-reader.c
@@ -32,7 +32,7 @@ struct _SpeechProviderStreamReader
 typedef struct
 {
   gint fd;
-  gboolean stream_header_recieved;
+  gboolean stream_header_received;
   SpeechProviderChunkType next_chunk_type;
 } SpeechProviderStreamReaderPrivate;
 
@@ -92,7 +92,7 @@ speech_provider_stream_reader_close (SpeechProviderStreamReader *self)
  *
  * Retrieves stream header.
  *
- * Returns: %TRUE if header successfully recieved.
+ * Returns: %TRUE if header successfully received.
  */
 gboolean
 speech_provider_stream_reader_get_stream_header (
@@ -103,10 +103,10 @@ speech_provider_stream_reader_get_stream_header (
   SpeechProviderStreamHeader header;
 
   g_return_val_if_fail (SPEECH_PROVIDER_IS_STREAM_WRITER (self), FALSE);
-  g_assert (!priv->stream_header_recieved);
+  g_assert (!priv->stream_header_received);
 
   read (priv->fd, &header, sizeof (SpeechProviderStreamHeader));
-  priv->stream_header_recieved = TRUE;
+  priv->stream_header_received = TRUE;
   return strncmp (header.version, SPEECH_PROVIDER_STREAM_PROTOCOL_VERSION, 4) ==
          0;
 }
@@ -147,7 +147,7 @@ speech_provider_stream_reader_get_audio (SpeechProviderStreamReader *self,
   g_return_val_if_fail (chunk_size != NULL, FALSE);
 
   chunk_type = _get_next_chunk_type (self);
-  g_assert (priv->stream_header_recieved);
+  g_assert (priv->stream_header_received);
   if (chunk_type != SPEECH_PROVIDER_CHUNK_TYPE_AUDIO)
     {
       *chunk_size = 0;
@@ -189,7 +189,7 @@ speech_provider_stream_reader_get_event (SpeechProviderStreamReader *self,
   g_return_val_if_fail (range_start != NULL, FALSE);
   g_return_val_if_fail (range_end != NULL, FALSE);
   g_return_val_if_fail (mark_name != NULL && *mark_name == NULL, FALSE);
-  g_assert (priv->stream_header_recieved);
+  g_assert (priv->stream_header_received);
 
   if (chunk_type != SPEECH_PROVIDER_CHUNK_TYPE_EVENT)
     {
@@ -277,6 +277,6 @@ speech_provider_stream_reader_init (SpeechProviderStreamReader *self)
 {
   SpeechProviderStreamReaderPrivate *priv =
       speech_provider_stream_reader_get_instance_private (self);
-  priv->stream_header_recieved = FALSE;
+  priv->stream_header_received = FALSE;
   priv->next_chunk_type = SPEECH_PROVIDER_CHUNK_TYPE_NONE;
 }

--- a/libspeechprovider/speech-provider-stream-writer.c
+++ b/libspeechprovider/speech-provider-stream-writer.c
@@ -24,6 +24,13 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+/**
+ * SpeechProviderStreamWriter:
+ *
+ * A provider audio stream writer.
+ *
+ * Since: 1.0
+ */
 struct _SpeechProviderStreamWriter
 {
   GObject parent_instance;
@@ -52,9 +59,11 @@ static GParamSpec *properties[N_PROPS];
  * speech_provider_stream_writer_new: (constructor)
  * @fd: The file descriptor for a pipe
  *
- * Creates a new #SpeechProviderStreamWriter.
+ * Creates a new [class@SpeechProvider.StreamWriter].
  *
- * Returns: The new #SpeechProviderStreamWriter.
+ * Returns: (transfer full): The new `SpeechProviderStreamWriter`
+ *
+ * Since: 1.0
  */
 SpeechProviderStreamWriter *
 speech_provider_stream_writer_new (gint fd)
@@ -70,9 +79,11 @@ speech_provider_stream_writer_new (gint fd)
 
 /**
  * speech_provider_stream_writer_close:
+ * @self: a `SpeechProviderStreamWriter`
  *
- * Close the pipe.
+ * Close the writer.
  *
+ * Since: 1.0
  */
 void
 speech_provider_stream_writer_close (SpeechProviderStreamWriter *self)
@@ -88,9 +99,11 @@ speech_provider_stream_writer_close (SpeechProviderStreamWriter *self)
 
 /**
  * speech_provider_stream_writer_send_stream_header:
+ * @self: a `SpeechProviderStreamWriter`
  *
- * Sends initial stream header
+ * Sends the initial stream header.
  *
+ * Since: 1.0
  */
 void
 speech_provider_stream_writer_send_stream_header (
@@ -111,11 +124,13 @@ speech_provider_stream_writer_send_stream_header (
 
 /**
  * speech_provider_stream_writer_send_audio:
+ * @self: a `SpeechProviderStreamWriter`
  * @chunk: (array length=chunk_size) (not nullable): audio data
  * @chunk_size: audio chunk size
  *
- * Sends audio chunk
+ * Sends a chunk of audio data.
  *
+ * Since: 1.0
  */
 void
 speech_provider_stream_writer_send_audio (SpeechProviderStreamWriter *self,
@@ -137,9 +152,11 @@ speech_provider_stream_writer_send_audio (SpeechProviderStreamWriter *self,
 
 /**
  * speech_provider_stream_writer_send_event:
+ * @self: a `SpeechProviderStreamWriter`
  *
- * Sends event
+ * Sends an event.
  *
+ * Since: 1.0
  */
 void
 speech_provider_stream_writer_send_event (SpeechProviderStreamWriter *self,
@@ -233,8 +250,9 @@ speech_provider_stream_writer_class_init (
   /**
    * SpeechProviderStreamWriter:fd:
    *
-   * File descriptor for pipe
+   * File descriptor for the stream.
    *
+   * Since: 1.0
    */
   properties[PROP_FD] =
       g_param_spec_int ("fd", NULL, NULL, -1, G_MAXINT32, 0,

--- a/libspeechprovider/speech-provider-stream-writer.c
+++ b/libspeechprovider/speech-provider-stream-writer.c
@@ -79,6 +79,9 @@ speech_provider_stream_writer_close (SpeechProviderStreamWriter *self)
 {
   SpeechProviderStreamWriterPrivate *priv =
       speech_provider_stream_writer_get_instance_private (self);
+
+  g_return_if_fail (SPEECH_PROVIDER_IS_STREAM_WRITER (self));
+
   close (priv->fd);
   priv->fd = -1;
 }
@@ -98,6 +101,9 @@ speech_provider_stream_writer_send_stream_header (
   SpeechProviderStreamHeader header = {
     .version = SPEECH_PROVIDER_STREAM_PROTOCOL_VERSION
   };
+
+  g_return_if_fail (SPEECH_PROVIDER_IS_STREAM_WRITER (self));
+
   g_assert (!priv->stream_header_sent);
   write (priv->fd, &header, sizeof (SpeechProviderStreamHeader));
   priv->stream_header_sent = TRUE;
@@ -105,7 +111,7 @@ speech_provider_stream_writer_send_stream_header (
 
 /**
  * speech_provider_stream_writer_send_audio:
- * @chunk: (array length=chunk_size): audio data
+ * @chunk: (array length=chunk_size) (not nullable): audio data
  * @chunk_size: audio chunk size
  *
  * Sends audio chunk
@@ -120,6 +126,8 @@ speech_provider_stream_writer_send_audio (SpeechProviderStreamWriter *self,
       speech_provider_stream_writer_get_instance_private (self);
   SpeechProviderChunkType chunk_type = SPEECH_PROVIDER_CHUNK_TYPE_AUDIO;
 
+  g_return_if_fail (SPEECH_PROVIDER_IS_STREAM_WRITER (self));
+  g_return_if_fail (chunk != NULL);
   g_assert (priv->stream_header_sent);
 
   write (priv->fd, &chunk_type, sizeof (SpeechProviderChunkType));
@@ -145,11 +153,13 @@ speech_provider_stream_writer_send_event (SpeechProviderStreamWriter *self,
   SpeechProviderChunkType chunk_type = SPEECH_PROVIDER_CHUNK_TYPE_EVENT;
   SpeechProviderEventData event_data = { .event_type = event_type,
                                          .range_start = range_start,
-                                         .range_end = range_end,
-                                         .mark_name_length =
-                                             g_utf8_strlen (mark_name, -1) };
+                                         .range_end = range_end };
+
+  g_return_if_fail (SPEECH_PROVIDER_IS_STREAM_WRITER (self));
+  g_return_if_fail (mark_name != NULL);
   g_assert (priv->stream_header_sent);
 
+  event_data.mark_name_length = g_utf8_strlen (mark_name, -1);
   write (priv->fd, &chunk_type, sizeof (SpeechProviderChunkType));
   write (priv->fd, &event_data, sizeof (SpeechProviderEventData));
   if (event_data.mark_name_length)

--- a/libspiel/meson.build
+++ b/libspiel/meson.build
@@ -85,10 +85,10 @@ spiel_lib_generated = [
 ]
 
 spiel_deps = [
-  dependency('gio-2.0'),
-  dependency('gio-unix-2.0'),
-  dependency('gstreamer-1.0'),
-  dependency('gstreamer-audio-1.0'),
+  dependency('gio-2.0', version: glib_version),
+  dependency('gio-unix-2.0', version: glib_version),
+  dependency('gstreamer-1.0', version: gst_version),
+  dependency('gstreamer-audio-1.0', version: gst_version),
   speech_provider_lib_dep
 ]
 
@@ -147,3 +147,4 @@ if compile_schemas.found()
     args: ['--strict', '--dry-run', meson.current_source_dir()]
   )
 endif
+

--- a/libspiel/spiel-provider.c
+++ b/libspiel/spiel-provider.c
@@ -28,6 +28,7 @@
  *
  * Represents a provider speech backend.
  *
+ * Since: 1.0
  */
 
 struct _SpielProvider
@@ -63,12 +64,27 @@ static gboolean handle_voices_changed (SpielProviderProxy *provider_proxy,
 
 static void _spiel_provider_update_voices (SpielProvider *self);
 
+
+/*< private >
+ * spiel_provider_new: (constructor)
+ *
+ * Creates a new [class@Spiel.Provider].
+ *
+ * Returns: (transfer full): The new `SpielProvider`.
+ */
 SpielProvider *
 spiel_provider_new (void)
 {
   return g_object_new (SPIEL_TYPE_PROVIDER, NULL);
 }
 
+/*< private >
+ * spiel_provider_set_proxy:
+ * @self: a `SpielProvider`
+ * @provider_proxy: a `SpielProviderProxy`
+ *
+ * Sets the internal D-Bus proxy.
+ */
 void
 spiel_provider_set_proxy (SpielProvider *self,
                           SpielProviderProxy *provider_proxy)
@@ -87,6 +103,14 @@ spiel_provider_set_proxy (SpielProvider *self,
                         G_CALLBACK (handle_voices_changed), self);
 }
 
+/*< private >
+ * spiel_provider_get_proxy:
+ * @self: a `SpielProvider`
+ *
+ * Gets the internal D-Bus proxy.
+ *
+ * Returns: (transfer none): a `SpielProviderProxy`
+ */
 SpielProviderProxy *
 spiel_provider_get_proxy (SpielProvider *self)
 {
@@ -97,6 +121,15 @@ spiel_provider_get_proxy (SpielProvider *self)
   return priv->provider_proxy;
 }
 
+/*< private >
+ * spiel_provider_get_voice_by_id:
+ * @self: a `SpielProvider`
+ * @voice_id: (not nullable): a voice ID
+ *
+ * Lookup a `SpielVoice` by ID.
+ *
+ * Returns: (transfer none) (nullable): a `SpielProviderProxy`
+ */
 SpielVoice *
 spiel_provider_get_voice_by_id (SpielProvider *self, const char *voice_id)
 {
@@ -121,12 +154,14 @@ spiel_provider_get_voice_by_id (SpielProvider *self, const char *voice_id)
 }
 
 /**
- * spiel_provider_proxy_get_name: (get-property name)
- * @self: a #SpielProvider
+ * spiel_provider_get_name: (get-property name)
+ * @self: a `SpielProvider`
  *
- * Fetches a human readable name of this provider
+ * Gets a human readable name of this provider
  *
  * Returns: (transfer none): the human readable name.
+ *
+ * Since: 1.0
  */
 const char *
 spiel_provider_get_name (SpielProvider *self)
@@ -141,11 +176,13 @@ spiel_provider_get_name (SpielProvider *self)
 
 /**
  * spiel_provider_get_well_known_name: (get-property well-known-name)
- * @self: a #SpielProvider
+ * @self: a `SpielProvider`
  *
- * Fetches the provider's D-Bus well known name.
+ * Gets the provider's D-Bus well known name.
  *
  * Returns: (transfer none): the well known name.
+ *
+ * Since: 1.0
  */
 const char *
 spiel_provider_get_well_known_name (SpielProvider *self)
@@ -160,11 +197,13 @@ spiel_provider_get_well_known_name (SpielProvider *self)
 
 /**
  * spiel_provider_get_voices: (get-property voices)
- * @self: a #SpielProvider
- * *
- * Fetches the provider's voices.
+ * @self: a `SpielProvider`
  *
- * Returns: (transfer none): A list of #SpielVoice voices provided
+ * Gets the provider's voices.
+ *
+ * Returns: (transfer none): A list of available voices
+ *
+ * Since: 1.0
  */
 GListModel *
 spiel_provider_get_voices (SpielProvider *self)
@@ -176,6 +215,13 @@ spiel_provider_get_voices (SpielProvider *self)
   return G_LIST_MODEL (priv->voices);
 }
 
+/*< private >
+ * spiel_provider_set_is_activatable:
+ * @self: a `SpielProvider`
+ * @is_activatable: %TRUE if activatable
+ *
+ * Sets whether the provider supports D-Bus activation.
+ */
 void
 spiel_provider_set_is_activatable (SpielProvider *self, gboolean is_activatable)
 {
@@ -186,6 +232,14 @@ spiel_provider_set_is_activatable (SpielProvider *self, gboolean is_activatable)
   priv->is_activatable = is_activatable;
 }
 
+/*< private >
+ * spiel_provider_get_is_activatable:
+ * @self: a `SpielProvider`
+ *
+ * Gets whether the provider supports D-Bus activation.
+ *
+ * Returns: %TRUE if activatable
+ */
 gboolean
 spiel_provider_get_is_activatable (SpielProvider *self)
 {
@@ -314,6 +368,18 @@ handle_voices_changed (SpielProviderProxy *provider_proxy,
   return TRUE;
 }
 
+/*< private >
+ * spiel_provider_compare:
+ * @self: (not nullable): a `SpielProvider`
+ * @other: (not nullable): a `SpielProvider` to compare with @self
+ * @user_data: user-defined callback data
+ *
+ * Compares the two [class@Spiel.Provider] values and returns a negative integer
+ * if the first value comes before the second, 0 if they are equal, or a
+ * positive integer if the first value comes after the second.
+ *
+ * Returns: an integer indicating order
+ */
 gint
 spiel_provider_compare (SpielProvider *self,
                         SpielProvider *other,
@@ -378,6 +444,7 @@ spiel_provider_class_init (SpielProviderClass *klass)
    *
    * The provider's human readable name
    *
+   * Since: 1.0
    */
   properties[PROP_NAME] =
       g_param_spec_string ("name", NULL, NULL, NULL /* default value */,
@@ -388,16 +455,18 @@ spiel_provider_class_init (SpielProviderClass *klass)
    *
    * The provider's D-Bus well known name.
    *
+   * Since: 1.0
    */
   properties[PROP_WELL_KNOWN_NAME] = g_param_spec_string (
       "well-known-name", NULL, NULL, NULL /* default value */,
       G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
   /**
-   * SpielProvider:voices:
+   * SpielProvider:voices: (getter get_voices)
    *
-   * The list of available [class@Voice]s that are provided.
+   * The list of available [class@Spiel.Voice]s that are provided.
    *
+   * Since: 1.0
    */
   properties[PROP_VOICES] =
       g_param_spec_object ("voices", NULL, NULL, G_TYPE_LIST_MODEL,

--- a/libspiel/spiel-provider.c
+++ b/libspiel/spiel-provider.c
@@ -74,6 +74,8 @@ spiel_provider_set_proxy (SpielProvider *self,
                           SpielProviderProxy *provider_proxy)
 {
   SpielProviderPrivate *priv = spiel_provider_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_PROVIDER (self));
   g_assert (!priv->provider_proxy);
 
   priv->provider_proxy = g_object_ref (provider_proxy);
@@ -89,6 +91,9 @@ SpielProviderProxy *
 spiel_provider_get_proxy (SpielProvider *self)
 {
   SpielProviderPrivate *priv = spiel_provider_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_PROVIDER (self), NULL);
+
   return priv->provider_proxy;
 }
 
@@ -96,7 +101,12 @@ SpielVoice *
 spiel_provider_get_voice_by_id (SpielProvider *self, const char *voice_id)
 {
   SpielProviderPrivate *priv = spiel_provider_get_instance_private (self);
-  guint voices_count = g_list_model_get_n_items (G_LIST_MODEL (priv->voices));
+  guint voices_count = 0;
+
+  g_return_val_if_fail (SPIEL_IS_PROVIDER (self), NULL);
+  g_return_val_if_fail (voice_id != NULL, NULL);
+
+  voices_count = g_list_model_get_n_items (G_LIST_MODEL (priv->voices));
 
   for (guint i = 0; i < voices_count; i++)
     {
@@ -122,6 +132,8 @@ const char *
 spiel_provider_get_name (SpielProvider *self)
 {
   SpielProviderPrivate *priv = spiel_provider_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_PROVIDER (self), NULL);
   g_return_val_if_fail (priv->provider_proxy, NULL);
 
   return spiel_provider_proxy_get_name (priv->provider_proxy);
@@ -139,6 +151,8 @@ const char *
 spiel_provider_get_well_known_name (SpielProvider *self)
 {
   SpielProviderPrivate *priv = spiel_provider_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_PROVIDER (self), NULL);
   g_return_val_if_fail (priv->provider_proxy, NULL);
 
   return g_dbus_proxy_get_name (G_DBUS_PROXY (priv->provider_proxy));
@@ -157,6 +171,8 @@ spiel_provider_get_voices (SpielProvider *self)
 {
   SpielProviderPrivate *priv = spiel_provider_get_instance_private (self);
 
+  g_return_val_if_fail (SPIEL_IS_PROVIDER (self), NULL);
+
   return G_LIST_MODEL (priv->voices);
 }
 
@@ -164,6 +180,9 @@ void
 spiel_provider_set_is_activatable (SpielProvider *self, gboolean is_activatable)
 {
   SpielProviderPrivate *priv = spiel_provider_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_PROVIDER (self));
+
   priv->is_activatable = is_activatable;
 }
 
@@ -171,6 +190,9 @@ gboolean
 spiel_provider_get_is_activatable (SpielProvider *self)
 {
   SpielProviderPrivate *priv = spiel_provider_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_PROVIDER (self), FALSE);
+
   return priv->is_activatable;
 }
 
@@ -297,6 +319,9 @@ spiel_provider_compare (SpielProvider *self,
                         SpielProvider *other,
                         gpointer user_data)
 {
+  g_return_val_if_fail (SPIEL_IS_PROVIDER (self), 0);
+  g_return_val_if_fail (SPIEL_IS_PROVIDER (other), 0);
+
   return g_strcmp0 (spiel_provider_get_well_known_name (self),
                     spiel_provider_get_well_known_name (other));
 }

--- a/libspiel/spiel-provider.c
+++ b/libspiel/spiel-provider.c
@@ -64,7 +64,6 @@ static gboolean handle_voices_changed (SpielProviderProxy *provider_proxy,
 
 static void _spiel_provider_update_voices (SpielProvider *self);
 
-
 /*< private >
  * spiel_provider_new: (constructor)
  *

--- a/libspiel/spiel-registry.c
+++ b/libspiel/spiel-registry.c
@@ -299,6 +299,8 @@ spiel_registry_get (GCancellable *cancellable,
                     GAsyncReadyCallback callback,
                     gpointer user_data)
 {
+  g_return_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable));
+
   if (sRegistry != NULL)
     {
       GTask *task = g_task_new (g_object_ref (sRegistry), cancellable, callback,
@@ -327,6 +329,9 @@ spiel_registry_get_finish (GAsyncResult *result, GError **error)
   g_autoptr (GObject) source_object = g_async_result_get_source_object (result);
   g_assert (source_object != NULL);
 
+  g_return_val_if_fail (G_IS_ASYNC_INITABLE (source_object), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+
   object = g_async_initable_new_finish (G_ASYNC_INITABLE (source_object),
                                         result, error);
   if (object != NULL)
@@ -348,6 +353,9 @@ spiel_registry_get_finish (GAsyncResult *result, GError **error)
 SpielRegistry *
 spiel_registry_get_sync (GCancellable *cancellable, GError **error)
 {
+  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+
   if (sRegistry == NULL)
     {
       gst_init_check (NULL, NULL, error);
@@ -513,11 +521,15 @@ initable_iface_init (GInitableIface *initable_iface)
 SpielProviderProxy *
 spiel_registry_get_provider_for_voice (SpielRegistry *self, SpielVoice *voice)
 {
-  SpielProvider *provider = spiel_voice_get_provider (voice);
+  SpielProvider *voice_provider = NULL;
 
-  g_return_val_if_fail (provider, NULL);
+  g_return_val_if_fail (SPIEL_IS_REGISTRY (self), NULL);
+  g_return_val_if_fail (SPIEL_IS_VOICE (voice), NULL);
 
-  return spiel_provider_get_proxy (provider);
+  voice_provider = spiel_voice_get_provider (voice);
+  g_return_val_if_fail (SPIEL_IS_PROVIDER (voice_provider), NULL);
+
+  return spiel_provider_get_proxy (voice_provider);
 }
 
 static SpielVoice *
@@ -566,14 +578,19 @@ spiel_registry_get_voice_for_utterance (SpielRegistry *self,
   SpielRegistryPrivate *priv = spiel_registry_get_instance_private (self);
   g_autofree char *provider_name = NULL;
   g_autofree char *voice_id = NULL;
-  const char *language = spiel_utterance_get_language (utterance);
+  const char *language = NULL;
+  SpielVoice *voice = NULL;
 
-  SpielVoice *voice = spiel_utterance_get_voice (utterance);
+  g_return_val_if_fail (SPIEL_IS_REGISTRY (self), NULL);
+  g_return_val_if_fail (SPIEL_IS_VOICE (utterance), NULL);
+
+  voice = spiel_utterance_get_voice (utterance);
   if (voice)
     {
       return voice;
     }
 
+  language = spiel_utterance_get_language (utterance);
   if (language && priv->settings)
     {
       g_autoptr (GVariant) mapping =
@@ -620,6 +637,9 @@ GListModel *
 spiel_registry_get_voices (SpielRegistry *self)
 {
   SpielRegistryPrivate *priv = spiel_registry_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_REGISTRY (self), NULL);
+
   return G_LIST_MODEL (priv->voices);
 }
 
@@ -627,5 +647,8 @@ GListModel *
 spiel_registry_get_providers (SpielRegistry *self)
 {
   SpielRegistryPrivate *priv = spiel_registry_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_REGISTRY (self), NULL);
+
   return G_LIST_MODEL (priv->providers);
 }

--- a/libspiel/spiel-registry.c
+++ b/libspiel/spiel-registry.c
@@ -521,7 +521,7 @@ initable_iface_init (GInitableIface *initable_iface)
 SpielProviderProxy *
 spiel_registry_get_provider_for_voice (SpielRegistry *self, SpielVoice *voice)
 {
-  SpielProvider *voice_provider = NULL;
+  g_autoptr (SpielProvider) voice_provider = NULL;
 
   g_return_val_if_fail (SPIEL_IS_REGISTRY (self), NULL);
   g_return_val_if_fail (SPIEL_IS_VOICE (voice), NULL);

--- a/libspiel/spiel-registry.c
+++ b/libspiel/spiel-registry.c
@@ -353,7 +353,8 @@ spiel_registry_get_finish (GAsyncResult *result, GError **error)
 SpielRegistry *
 spiel_registry_get_sync (GCancellable *cancellable, GError **error)
 {
-  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
+  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable),
+                        NULL);
   g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
   if (sRegistry == NULL)

--- a/libspiel/spiel-speaker.c
+++ b/libspiel/spiel-speaker.c
@@ -35,8 +35,9 @@
  *
  * A virtual speaker for speech synthesis
  *
- * The `SpielSpeaker` class represents a single "individual" speaker. Its primary
- * method is [method@Spiel.Speaker.speak] which queues utterances to be spoken.
+ * The `SpielSpeaker` class represents a single "individual" speaker. Its
+ * primary method is [method@Spiel.Speaker.speak] which queues utterances to be
+ * spoken.
  *
  * This class also provides a list of available voices provided by DBus speech
  * providers that are activatable on the session bus.
@@ -236,7 +237,8 @@ spiel_speaker_new_finish (GAsyncResult *result, GError **error)
 SpielSpeaker *
 spiel_speaker_new_sync (GCancellable *cancellable, GError **error)
 {
-  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
+  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable),
+                        NULL);
   g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
   return g_initable_new (SPIEL_TYPE_SPEAKER, cancellable, error, NULL);
@@ -547,9 +549,7 @@ _setup_pipeline (SpielSpeaker *self, GError **error)
     {
       if (error != NULL && *error == NULL)
         {
-          g_set_error_literal (error,
-                               GST_CORE_ERROR,
-                               GST_CORE_ERROR_FAILED,
+          g_set_error_literal (error, GST_CORE_ERROR, GST_CORE_ERROR_FAILED,
                                "Failed to create 'autoaudiosink' element; "
                                "ensure GStreamer Good Plug-ins are installed");
         }

--- a/libspiel/spiel-speaker.c
+++ b/libspiel/spiel-speaker.c
@@ -697,7 +697,7 @@ typedef struct
  *
  * Speak the given utterance. If an utterance is already being spoken
  * the provided utterances will be added to a queue and will be spoken
- * in the order recieved.
+ * in the order received.
  */
 void
 spiel_speaker_speak (SpielSpeaker *self, SpielUtterance *utterance)

--- a/libspiel/spiel-speaker.c
+++ b/libspiel/spiel-speaker.c
@@ -179,6 +179,8 @@ spiel_speaker_new (GCancellable *cancellable,
                    GAsyncReadyCallback callback,
                    gpointer user_data)
 {
+  g_return_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable));
+
   g_async_initable_new_async (SPIEL_TYPE_SPEAKER, G_PRIORITY_DEFAULT,
                               cancellable, callback, user_data, NULL);
 }
@@ -200,7 +202,8 @@ spiel_speaker_new_finish (GAsyncResult *result, GError **error)
   GObject *object;
   g_autoptr (GObject) source_object = g_async_result_get_source_object (result);
 
-  g_return_val_if_fail (source_object != NULL, NULL);
+  g_return_val_if_fail (G_IS_ASYNC_INITABLE (source_object), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
   object = g_async_initable_new_finish (G_ASYNC_INITABLE (source_object),
                                         result, error);
@@ -227,6 +230,9 @@ spiel_speaker_new_finish (GAsyncResult *result, GError **error)
 SpielSpeaker *
 spiel_speaker_new_sync (GCancellable *cancellable, GError **error)
 {
+  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+
   return g_initable_new (SPIEL_TYPE_SPEAKER, cancellable, error, NULL);
 }
 
@@ -711,6 +717,9 @@ spiel_speaker_speak (SpielSpeaker *self, SpielUtterance *utterance)
   g_autoptr (SpielVoice) voice = NULL;
   GstStructure *gst_struct;
 
+  g_return_if_fail (SPIEL_IS_SPEAKER (self));
+  g_return_if_fail (SPIEL_IS_UTTERANCE (utterance));
+
   g_object_get (utterance, "pitch", &pitch, "rate", &rate, "volume", &volume,
                 "voice", &voice, "is-ssml", &is_ssml, NULL);
 
@@ -824,6 +833,8 @@ spiel_speaker_get_voices (SpielSpeaker *self)
 {
   SpielSpeakerPrivate *priv = spiel_speaker_get_instance_private (self);
 
+  g_return_val_if_fail (SPIEL_IS_SPEAKER (self), NULL);
+
   return spiel_registry_get_voices (priv->registry);
 }
 
@@ -839,6 +850,8 @@ GListModel *
 spiel_speaker_get_providers (SpielSpeaker *self)
 {
   SpielSpeakerPrivate *priv = spiel_speaker_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_SPEAKER (self), NULL);
 
   return spiel_registry_get_providers (priv->registry);
 }
@@ -856,10 +869,18 @@ void
 spiel_speaker_pause (SpielSpeaker *self)
 {
   SpielSpeakerPrivate *priv = spiel_speaker_get_instance_private (self);
-  _QueueEntry *entry = priv->queue ? priv->queue->data : NULL;
+  _QueueEntry *entry = NULL;
+
+  g_return_if_fail (SPIEL_IS_SPEAKER (self));
+
   if (priv->paused)
     {
       return;
+    }
+
+  if (priv->queue)
+    {
+      entry = priv->queue->data;
     }
 
   if (!entry)
@@ -883,10 +904,18 @@ void
 spiel_speaker_resume (SpielSpeaker *self)
 {
   SpielSpeakerPrivate *priv = spiel_speaker_get_instance_private (self);
-  _QueueEntry *entry = priv->queue ? priv->queue->data : NULL;
+  _QueueEntry *entry = NULL;
+
+  g_return_if_fail (SPIEL_IS_SPEAKER (self));
+
   if (!priv->paused)
     {
       return;
+    }
+
+  if (priv->queue)
+    {
+      entry = priv->queue->data;
     }
 
   if (!entry)
@@ -909,6 +938,9 @@ void
 spiel_speaker_cancel (SpielSpeaker *self)
 {
   SpielSpeakerPrivate *priv = spiel_speaker_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_SPEAKER (self));
+
   if (!priv->queue)
     {
       return;

--- a/libspiel/spiel-speaker.c
+++ b/libspiel/spiel-speaker.c
@@ -35,17 +35,18 @@
  *
  * A virtual speaker for speech synthesis
  *
- * The #SpielSpeaker class represents a single "individual" speaker. Its primary
- * method is [method@Speaker.speak] which queues utterances to be spoken.
+ * The `SpielSpeaker` class represents a single "individual" speaker. Its primary
+ * method is [method@Spiel.Speaker.speak] which queues utterances to be spoken.
  *
  * This class also provides a list of available voices provided by DBus speech
  * providers that are activatable on the session bus.
  *
- * #SpielSpeaker's initialization may perform blocking IO if it the first
+ * `SpielSpeaker`'s initialization may perform blocking IO if it the first
  * instance in the process. The default constructor is asynchronous
- * ([func@Speaker.new]), although there is a synchronous blocking alternative
- * ([ctor@Speaker.new_sync]).
+ * ([func@Spiel.Speaker.new]), although there is a synchronous blocking
+ * alternative ([ctor@Spiel.Speaker.new_sync]).
  *
+ * Since: 1.0
  */
 
 struct _SpielSpeaker
@@ -160,19 +161,21 @@ _queue_entry_destroy (gpointer data)
 
 /**
  * spiel_speaker_new:
- * @cancellable: (nullable): A #GCancellable or %NULL.
+ * @cancellable: (nullable): optional `GCancellable`.
  * @callback: A #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: User data to pass to @callback.
  *
- * Asynchronously creates a SpielSpeaker.
+ * Asynchronously creates a [class@Spiel.Speaker].
  *
  * When the operation is finished, @callback will be invoked in the
  * thread-default main loop of the thread you are calling this method from (see
- * g_main_context_push_thread_default()). You can then call
- * spiel_speaker_new_finish() to get the result of the operation.
+ * [method@GLib.MainContext.push_thread_default]). You can then call
+ * [ctor@Spiel.Speaker.new_finish] to get the result of the operation.
  *
- * See spiel_speaker_new_sync() for the synchronous, blocking version of this
- * constructor.
+ * See [ctor@Spiel.Speaker.new_sync] for the synchronous, blocking version of
+ * this constructor.
+ *
+ * Since: 1.0
  */
 void
 spiel_speaker_new (GCancellable *cancellable,
@@ -186,15 +189,16 @@ spiel_speaker_new (GCancellable *cancellable,
 }
 
 /**
- * spiel_speaker_new_finish:
- * @result: The #GAsyncResult obtained from the #GAsyncReadyCallback passed to
- * spiel_speaker_new().
- * @error: Return location for error or %NULL
+ * spiel_speaker_new_finish: (constructor)
+ * @result: The `GAsyncResult` obtained from the `GAsyncReadyCallback` passed to
+ * [func@Spiel.Speaker.new].
+ * @error: (nullable): optional `GError`
  *
- * Finishes an operation started with spiel_speaker_new().
+ * Finishes an operation started with [func@Spiel.Speaker.new].
  *
- * Returns: (transfer full) (type SpielSpeaker): The constructed speaker object
- * or %NULL if @error is set.
+ * Returns: (transfer full): The new `SpielSpeaker`, or %NULL with @error set
+ *
+ * Since: 1.0
  */
 SpielSpeaker *
 spiel_speaker_new_finish (GAsyncResult *result, GError **error)
@@ -215,7 +219,7 @@ spiel_speaker_new_finish (GAsyncResult *result, GError **error)
 
 /**
  * spiel_speaker_new_sync:
- * @cancellable: (nullable): A #GCancellable or %NULL.
+ * @cancellable: (nullable): A optional `GCancellable`.
  * @error: Return location for error or %NULL
  *
  * Synchronously creates a SpielSpeaker.
@@ -226,6 +230,8 @@ spiel_speaker_new_finish (GAsyncResult *result, GError **error)
  *
  * Returns: (transfer full) (type SpielSpeaker): The constructed speaker object
  * or %NULL if @error is set.
+ *
+ * Since: 1.0
  */
 SpielSpeaker *
 spiel_speaker_new_sync (GCancellable *cancellable, GError **error)
@@ -330,6 +336,7 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
    *
    * The speaker has an utterance queued or speaking.
    *
+   * Since: 1.0
    */
   properties[PROP_SPEAKING] =
       g_param_spec_boolean ("speaking", NULL, NULL, FALSE /* default value */,
@@ -340,26 +347,31 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
    *
    * The speaker is in a paused state.
    *
+   * See [method@Spiel.Speaker.pause] and [method@Spiel.Speaker.resume].
+   *
+   * Since: 1.0
    */
   properties[PROP_PAUSED] =
       g_param_spec_boolean ("paused", NULL, NULL, FALSE /* default value */,
                             G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
   /**
-   * SpielSpeaker:voices:
+   * SpielSpeaker:voices: (getter get_voices)
    *
    * The list of available [class@Voice]s that can be used in an utterance.
    *
+   * Since: 1.0
    */
   properties[PROP_VOICES] =
       g_param_spec_object ("voices", NULL, NULL, G_TYPE_LIST_MODEL,
                            G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
   /**
-   * SpielSpeaker:providers:
+   * SpielSpeaker:providers: (getter get_providers)
    *
    * The list of available [class@Provider]s that offer voices.
    *
+   * Since: 1.0
    */
   properties[PROP_PROVIDERS] =
       g_param_spec_object ("providers", NULL, NULL, G_TYPE_LIST_MODEL,
@@ -370,6 +382,7 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
    *
    * The gstreamer sink this speaker is connected to.
    *
+   * Since: 1.0
    */
   properties[PROP_SINK] = g_param_spec_object (
       "sink", NULL, NULL, GST_TYPE_ELEMENT, G_PARAM_READWRITE);
@@ -378,11 +391,12 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
 
   /**
    * SpielSpeaker::utterance-started:
-   * @speaker: A #SpielSpeaker
-   * @utterance: A #SpielUtterance
+   * @speaker: A `SpielSpeaker`
+   * @utterance: A `SpielUtterance`
    *
    * Emitted when the given utterance is actively being spoken.
    *
+   * Since: 1.0
    */
   speaker_signals[UTTURANCE_STARTED] = g_signal_new (
       "utterance-started", G_TYPE_FROM_CLASS (klass), G_SIGNAL_RUN_FIRST, 0,
@@ -390,11 +404,12 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
 
   /**
    * SpielSpeaker::utterance-finished:
-   * @speaker: A #SpielSpeaker
-   * @utterance: A #SpielUtterance
+   * @speaker: A `SpielSpeaker`
+   * @utterance: A `SpielUtterance`
    *
    * Emitted when a given utterance has completed speaking
    *
+   * Since: 1.0
    */
   speaker_signals[UTTERANCE_FINISHED] = g_signal_new (
       "utterance-finished", G_TYPE_FROM_CLASS (klass), G_SIGNAL_RUN_FIRST, 0,
@@ -402,12 +417,13 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
 
   /**
    * SpielSpeaker::utterance-canceled:
-   * @speaker: A #SpielSpeaker
-   * @utterance: A #SpielUtterance
+   * @speaker: A `SpielSpeaker`
+   * @utterance: A `SpielUtterance`
    *
    * Emitted when a given utterance has been canceled after it has started
    * speaking
    *
+   * Since: 1.0
    */
   speaker_signals[UTTERANCE_CANCELED] = g_signal_new (
       "utterance-canceled", G_TYPE_FROM_CLASS (klass), G_SIGNAL_RUN_FIRST, 0,
@@ -415,12 +431,13 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
 
   /**
    * SpielSpeaker::utterance-error:
-   * @speaker: A #SpielSpeaker
-   * @utterance: A #SpielUtterance
+   * @speaker: A `SpielSpeaker`
+   * @utterance: A `SpielUtterance`
    * @error: A #GError
    *
    * Emitted when a given utterance has failed to start or complete.
    *
+   * Since: 1.0
    */
   speaker_signals[UTTERANCE_ERROR] = g_signal_new (
       "utterance-error", G_TYPE_FROM_CLASS (klass), G_SIGNAL_RUN_FIRST, 0, NULL,
@@ -428,14 +445,15 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
 
   /**
    * SpielSpeaker::word-started:
-   * @speaker: A #SpielSpeaker
-   * @utterance: A #SpielUtterance
+   * @speaker: A `SpielSpeaker`
+   * @utterance: A `SpielUtterance`
    * @start: Character start offset of speech word
    * @end: Character end offset of speech word
    *
    * Emitted when a word will be spoken in a given utterance. Not all
    * voices are capable of notifying when a word will be spoken.
    *
+   * Since: 1.0
    */
   speaker_signals[WORD_STARTED] =
       g_signal_new ("word-started", G_TYPE_FROM_CLASS (klass),
@@ -444,14 +462,15 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
 
   /**
    * SpielSpeaker::sentence-started:
-   * @speaker: A #SpielSpeaker
-   * @utterance: A #SpielUtterance
+   * @speaker: A `SpielSpeaker`
+   * @utterance: A `SpielUtterance`
    * @start: Character start offset of speech sentence
    * @end: Character end offset of speech sentence
    *
    * Emitted when a sentence will be spoken in a given utterance. Not all
    * voices are capable of notifying when a sentence will be spoken.
    *
+   * Since: 1.0
    */
   speaker_signals[SENTENCE_STARTED] =
       g_signal_new ("sentence-started", G_TYPE_FROM_CLASS (klass),
@@ -460,14 +479,15 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
 
   /**
    * SpielSpeaker::range-started:
-   * @speaker: A #SpielSpeaker
-   * @utterance: A #SpielUtterance
+   * @speaker: A `SpielSpeaker`
+   * @utterance: A `SpielUtterance`
    * @start: Character start offset of speech range
    * @end: Character end offset of speech range
    *
    * Emitted when a range will be spoken in a given utterance. Not all
    * voices are capable of notifying when a range will be spoken.
    *
+   * Since: 1.0
    */
   speaker_signals[RANGE_STARTED] =
       g_signal_new ("range-started", G_TYPE_FROM_CLASS (klass),
@@ -476,12 +496,13 @@ spiel_speaker_class_init (SpielSpeakerClass *klass)
 
   /**
    * SpielSpeaker::mark-reached:
-   * @speaker: A #SpielSpeaker
-   * @utterance: A #SpielUtterance
+   * @speaker: A `SpielSpeaker`
+   * @utterance: A `SpielUtterance`
    * @name: Name of mark reached
    *
    * Emitted when an SSML mark element is reached
    *
+   * Since: 1.0
    */
   speaker_signals[MARK_REACHED] = g_signal_new (
       "mark-reached", G_TYPE_FROM_CLASS (klass), G_SIGNAL_RUN_FIRST, 0, NULL,
@@ -669,7 +690,7 @@ spiel_error_quark (void)
   return g_quark_from_static_string ("spiel-error-quark");
 }
 
-/**
+/*
  * Playback
  */
 
@@ -692,12 +713,14 @@ typedef struct
 
 /**
  * spiel_speaker_speak:
- * @self: a #SpielSpeaker
- * @utterance: an #SpielUtterance to speak
+ * @self: a `SpielSpeaker`
+ * @utterance: an `SpielUtterance` to speak
  *
  * Speak the given utterance. If an utterance is already being spoken
  * the provided utterances will be added to a queue and will be spoken
  * in the order received.
+ *
+ * Since: 1.0
  */
 void
 spiel_speaker_speak (SpielSpeaker *self, SpielUtterance *utterance)
@@ -822,11 +845,13 @@ spiel_speaker_speak (SpielSpeaker *self, SpielUtterance *utterance)
 
 /**
  * spiel_speaker_get_voices: (get-property voices)
- * @self: a #SpielSpeaker
+ * @self: a `SpielSpeaker`
  *
- * Fetches the voices available to this speaker
+ * Gets the voices available to this speaker.
  *
- * Returns: (transfer none): A live #ListModel of voices
+ * Returns: (transfer none): A `GListModel` of `SpielVoice`
+ *
+ * Since: 1.0
  */
 GListModel *
 spiel_speaker_get_voices (SpielSpeaker *self)
@@ -840,11 +865,13 @@ spiel_speaker_get_voices (SpielSpeaker *self)
 
 /**
  * spiel_speaker_get_providers: (get-property providers)
- * @self: a #SpielSpeaker
+ * @self: a `SpielSpeaker`
  *
- * Fetches the speech providers that offer voices to this speaker
+ * Gets the speech providers that offer voices to this speaker.
  *
- * Returns: (transfer none): A live #ListModel of providers
+ * Returns: (transfer none): A `GListModel` of `SpielProvider`
+ *
+ * Since: 1.0
  */
 GListModel *
 spiel_speaker_get_providers (SpielSpeaker *self)
@@ -858,12 +885,15 @@ spiel_speaker_get_providers (SpielSpeaker *self)
 
 /**
  * spiel_speaker_pause:
- * @self: a #SpielSpeaker
+ * @self: a `SpielSpeaker`
  *
  * Pause the given speaker. If an utterance is being spoken, it will pause
  * until [method@Speaker.resume] is called.
+ *
  * If the speaker isn't speaking, calling [method@Speaker.speak] will store
  * new utterances in a queue until [method@Speaker.resume] is called.
+ *
+ * Since: 1.0
  */
 void
 spiel_speaker_pause (SpielSpeaker *self)
@@ -895,10 +925,13 @@ spiel_speaker_pause (SpielSpeaker *self)
 
 /**
  * spiel_speaker_resume:
- * @self: a #SpielSpeaker
+ * @self: a `SpielSpeaker`
  *
- * Resumes the given paused speaker. If the speaker isn't pause this will do
- * nothing.
+ * Resumes the given paused speaker.
+ *
+ * If the speaker isn't paused this will do nothing.
+ *
+ * Since: 1.0
  */
 void
 spiel_speaker_resume (SpielSpeaker *self)
@@ -930,9 +963,11 @@ spiel_speaker_resume (SpielSpeaker *self)
 
 /**
  * spiel_speaker_cancel:
- * @self: a #SpielSpeaker
+ * @self: a `SpielSpeaker`
  *
  * Stops the current utterance from being spoken and dumps the utterance queue.
+ *
+ * Since: 1.0
  */
 void
 spiel_speaker_cancel (SpielSpeaker *self)

--- a/libspiel/spiel-utterance.c
+++ b/libspiel/spiel-utterance.c
@@ -92,6 +92,8 @@ spiel_utterance_get_text (SpielUtterance *self)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
 
+  g_return_val_if_fail (SPIEL_IS_UTTERANCE (self), NULL);
+
   return priv->text;
 }
 
@@ -107,6 +109,9 @@ void
 spiel_utterance_set_text (SpielUtterance *self, const char *text)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_UTTERANCE (self));
+
   g_free (priv->text);
   priv->text = g_strdup (text);
   g_object_notify (G_OBJECT (self), "text");
@@ -125,6 +130,8 @@ spiel_utterance_get_pitch (SpielUtterance *self)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
 
+  g_return_val_if_fail (SPIEL_IS_UTTERANCE (self), 1.0);
+
   return priv->pitch;
 }
 
@@ -140,6 +147,9 @@ void
 spiel_utterance_set_pitch (SpielUtterance *self, double pitch)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_UTTERANCE (self));
+
   priv->pitch = pitch;
   g_object_notify (G_OBJECT (self), "pitch");
 }
@@ -157,6 +167,8 @@ spiel_utterance_get_rate (SpielUtterance *self)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
 
+  g_return_val_if_fail (SPIEL_IS_UTTERANCE (self), 1.0);
+
   return priv->rate;
 }
 
@@ -172,6 +184,9 @@ void
 spiel_utterance_set_rate (SpielUtterance *self, double rate)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_UTTERANCE (self));
+
   priv->rate = rate;
   g_object_notify (G_OBJECT (self), "rate");
 }
@@ -189,6 +204,8 @@ spiel_utterance_get_volume (SpielUtterance *self)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
 
+  g_return_val_if_fail (SPIEL_IS_UTTERANCE (self), 1.0);
+
   return priv->volume;
 }
 
@@ -204,6 +221,9 @@ void
 spiel_utterance_set_volume (SpielUtterance *self, double volume)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_UTTERANCE (self));
+
   priv->volume = volume;
   g_object_notify (G_OBJECT (self), "volume");
 }
@@ -221,6 +241,8 @@ spiel_utterance_get_voice (SpielUtterance *self)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
 
+  g_return_val_if_fail (SPIEL_IS_UTTERANCE (self), NULL);
+
   return priv->voice;
 }
 
@@ -236,6 +258,10 @@ void
 spiel_utterance_set_voice (SpielUtterance *self, SpielVoice *voice)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_UTTERANCE (self));
+  g_return_if_fail (voice == NULL || SPIEL_IS_VOICE (voice));
+
   g_clear_object (&(priv->voice));
 
   priv->voice = voice ? g_object_ref (voice) : NULL;
@@ -255,6 +281,8 @@ spiel_utterance_get_language (SpielUtterance *self)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
 
+  g_return_val_if_fail (SPIEL_IS_UTTERANCE (self), NULL);
+
   return priv->language;
 }
 
@@ -270,6 +298,9 @@ void
 spiel_utterance_set_language (SpielUtterance *self, const char *language)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_UTTERANCE (self));
+
   g_free (priv->language);
   priv->language = g_strdup (language);
   g_object_notify (G_OBJECT (self), "language");
@@ -287,6 +318,9 @@ gboolean
 spiel_utterance_get_is_ssml (SpielUtterance *self)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_UTTERANCE (self), FALSE);
+
   return priv->is_ssml;
 }
 
@@ -302,6 +336,9 @@ void
 spiel_utterance_set_is_ssml (SpielUtterance *self, gboolean is_ssml)
 {
   SpielUtterancePrivate *priv = spiel_utterance_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_UTTERANCE (self));
+
   priv->is_ssml = is_ssml;
 }
 

--- a/libspiel/spiel-utterance.c
+++ b/libspiel/spiel-utterance.c
@@ -23,11 +23,12 @@
 /**
  * SpielUtterance:
  *
- * Represents an utterance to be spoken by a #SpielSpeaker.
+ * Represents an utterance to be spoken by a `SpielSpeaker`.
  *
  * An utterance consists of the text to be spoken and other properties that
  * affect the speech, like rate, pitch or voice used.
  *
+ * Since: 1.0
  */
 
 struct _SpielUtterance
@@ -67,11 +68,13 @@ static GParamSpec *properties[N_PROPS];
 
 /**
  * spiel_utterance_new: (constructor)
- * @text: (not nullable): The utterance text to be spoken.
+ * @text: (nullable): The utterance text to be spoken.
  *
- * Creates a new #SpielUtterance.
+ * Creates a new [class@Spiel.Utterance].
  *
- * Returns: The new #NotifyNotification.
+ * Returns: The new `SpielUtterance`.
+ *
+ * Since: 1.0
  */
 SpielUtterance *
 spiel_utterance_new (const char *text)
@@ -81,11 +84,13 @@ spiel_utterance_new (const char *text)
 
 /**
  * spiel_utterance_get_text: (get-property text)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  *
- * Fetches the text spoken in this utterance
+ * Gets the text spoken in this utterance.
  *
- * Returns: (transfer none): the text.
+ * Returns: (transfer none): the text
+ *
+ * Since: 1.0
  */
 const char *
 spiel_utterance_get_text (SpielUtterance *self)
@@ -99,11 +104,12 @@ spiel_utterance_get_text (SpielUtterance *self)
 
 /**
  * spiel_utterance_set_text: (set-property text)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  * @text: the text to assign to this utterance
  *
- * Sets the text to be spoken by this utterance
+ * Sets the text to be spoken by this utterance.
  *
+ * Since: 1.0
  */
 void
 spiel_utterance_set_text (SpielUtterance *self, const char *text)
@@ -119,11 +125,13 @@ spiel_utterance_set_text (SpielUtterance *self, const char *text)
 
 /**
  * spiel_utterance_get_pitch: (get-property pitch)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  *
- * Fetches the pitch used in this utterance
+ * Gets the pitch used in this utterance.
  *
- * Returns: the pitch value.
+ * Returns: the pitch value
+ *
+ * Since: 1.0
  */
 double
 spiel_utterance_get_pitch (SpielUtterance *self)
@@ -137,11 +145,12 @@ spiel_utterance_get_pitch (SpielUtterance *self)
 
 /**
  * spiel_utterance_set_pitch: (set-property pitch)
- * @self: a #SpielUtterance
- * @pitch: a rate to assign to this utterance
+ * @self: a `SpielUtterance`
+ * @pitch: a pitch to assign to this utterance
  *
- * Sets a pitch on this utterance
+ * Sets a pitch on this utterance.
  *
+ * Since: 1.0
  */
 void
 spiel_utterance_set_pitch (SpielUtterance *self, double pitch)
@@ -156,11 +165,13 @@ spiel_utterance_set_pitch (SpielUtterance *self, double pitch)
 
 /**
  * spiel_utterance_get_rate: (get-property rate)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  *
- * Fetches the rate used in this utterance
+ * Gets the rate used in this utterance.
  *
- * Returns: the rate value.
+ * Returns: the rate value
+ *
+ * Since: 1.0
  */
 double
 spiel_utterance_get_rate (SpielUtterance *self)
@@ -174,11 +185,12 @@ spiel_utterance_get_rate (SpielUtterance *self)
 
 /**
  * spiel_utterance_set_rate: (set-property rate)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  * @rate: a rate to assign to this utterance
  *
- * Sets a rate on this utterance
+ * Sets a rate on this utterance.
  *
+ * Since: 1.0
  */
 void
 spiel_utterance_set_rate (SpielUtterance *self, double rate)
@@ -193,11 +205,13 @@ spiel_utterance_set_rate (SpielUtterance *self, double rate)
 
 /**
  * spiel_utterance_get_volume: (get-property volume)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  *
- * Fetches the volume used in this utterance
+ * Gets the volume used in this utterance.
  *
- * Returns: the volume value.
+ * Returns: the volume value
+ *
+ * Since: 1.0
  */
 double
 spiel_utterance_get_volume (SpielUtterance *self)
@@ -211,11 +225,12 @@ spiel_utterance_get_volume (SpielUtterance *self)
 
 /**
  * spiel_utterance_set_volume: (set-property volume)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  * @volume: a volume to assign to this utterance
  *
- * Sets a volume on this utterance
+ * Sets a volume on this utterance.
  *
+ * Since: 1.0
  */
 void
 spiel_utterance_set_volume (SpielUtterance *self, double volume)
@@ -230,11 +245,13 @@ spiel_utterance_set_volume (SpielUtterance *self, double volume)
 
 /**
  * spiel_utterance_get_voice: (get-property voice)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  *
- * Fetches the voice used in this utterance
+ * Gets the voice used in this utterance
  *
- * Returns: (transfer none): the voice object.
+ * Returns: (transfer none) (nullable): a `SpielVoice`
+ *
+ * Since: 1.0
  */
 SpielVoice *
 spiel_utterance_get_voice (SpielUtterance *self)
@@ -248,11 +265,12 @@ spiel_utterance_get_voice (SpielUtterance *self)
 
 /**
  * spiel_utterance_set_voice: (set-property voice)
- * @self: a #SpielUtterance
- * @voice: a #SpielVoice to assign to this utterance
+ * @self: a `SpielUtterance`
+ * @voice: a `SpielVoice` to assign to this utterance
  *
- * Sets a voice on this utterance
+ * Sets a voice on this utterance.
  *
+ * Since: 1.0
  */
 void
 spiel_utterance_set_voice (SpielUtterance *self, SpielVoice *voice)
@@ -270,11 +288,13 @@ spiel_utterance_set_voice (SpielUtterance *self, SpielVoice *voice)
 
 /**
  * spiel_utterance_get_language: (get-property language)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  *
- * Fetches the language used in this utterance.
+ * Gets the language used in this utterance.
  *
- * Returns: (transfer none): the language.
+ * Returns: (transfer none): the language
+ *
+ * Since: 1.0
  */
 const char *
 spiel_utterance_get_language (SpielUtterance *self)
@@ -288,11 +308,12 @@ spiel_utterance_get_language (SpielUtterance *self)
 
 /**
  * spiel_utterance_set_language: (set-property language)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  * @language: the language to assign to this utterance
  *
  * Sets the language of this utterance
  *
+ * Since: 1.0
  */
 void
 spiel_utterance_set_language (SpielUtterance *self, const char *language)
@@ -308,11 +329,13 @@ spiel_utterance_set_language (SpielUtterance *self, const char *language)
 
 /**
  * spiel_utterance_get_is_ssml: (get-property is-ssml)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  *
- * Is the current utterance an SSML snippet
+ * Gets whether the current utterance an SSML snippet.
  *
- * Returns: the utterance text is SSML
+ * Returns: %TRUE if the utterance text is SSML
+ *
+ * Since: 1.0
  */
 gboolean
 spiel_utterance_get_is_ssml (SpielUtterance *self)
@@ -326,11 +349,12 @@ spiel_utterance_get_is_ssml (SpielUtterance *self)
 
 /**
  * spiel_utterance_set_is_ssml: (set-property is-ssml)
- * @self: a #SpielUtterance
+ * @self: a `SpielUtterance`
  * @is_ssml: whether the utterance text is an SSML snippet
  *
- * Indicates whether this utterance should be interpreted as SSML
+ * Indicates whether this utterance should be interpreted as SSML.
  *
+ * Since: 1.0
  */
 void
 spiel_utterance_set_is_ssml (SpielUtterance *self, gboolean is_ssml)
@@ -441,6 +465,7 @@ spiel_utterance_class_init (SpielUtteranceClass *klass)
    *
    * The utterance text that will be spoken.
    *
+   * Since: 1.0
    */
   properties[PROP_TEXT] =
       g_param_spec_string ("text", NULL, NULL, NULL /* default value */,
@@ -451,6 +476,7 @@ spiel_utterance_class_init (SpielUtteranceClass *klass)
    *
    * The pitch at which the utterance will be spoken.
    *
+   * Since: 1.0
    */
   properties[PROP_PITCH] = g_param_spec_double (
       "pitch", NULL, NULL, 0, 2, 1, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
@@ -460,6 +486,7 @@ spiel_utterance_class_init (SpielUtteranceClass *klass)
    *
    * The speed at which the utterance will be spoken.
    *
+   * Since: 1.0
    */
   properties[PROP_RATE] =
       g_param_spec_double ("rate", NULL, NULL, 0.1, 10, 1,
@@ -470,6 +497,7 @@ spiel_utterance_class_init (SpielUtteranceClass *klass)
    *
    * The volume at which the utterance will be spoken.
    *
+   * Since: 1.0
    */
   properties[PROP_VOLUME] =
       g_param_spec_double ("volume", NULL, NULL, 0, 1, 1,
@@ -480,6 +508,7 @@ spiel_utterance_class_init (SpielUtteranceClass *klass)
    *
    * The voice with which the utterance will be spoken.
    *
+   * Since: 1.0
    */
   properties[PROP_VOICE] =
       g_param_spec_object ("voice", NULL, NULL, SPIEL_TYPE_VOICE,
@@ -491,6 +520,7 @@ spiel_utterance_class_init (SpielUtteranceClass *klass)
    * The utterance language. If no voice is set this language will be used to
    * select the best matching voice.
    *
+   * Since: 1.0
    */
   properties[PROP_LANGUAGE] =
       g_param_spec_string ("language", NULL, NULL, NULL /* default value */,
@@ -501,6 +531,7 @@ spiel_utterance_class_init (SpielUtteranceClass *klass)
    *
    * Whether the utterance's text should be interpreted as an SSML snippet.
    *
+   * Since: 1.0
    */
   properties[PROP_IS_SSML] = g_param_spec_boolean (
       "is-ssml", NULL, NULL, FALSE, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);

--- a/libspiel/spiel-voice.c
+++ b/libspiel/spiel-voice.c
@@ -215,7 +215,7 @@ guint
 spiel_voice_hash (SpielVoice *self)
 {
   SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
-  SpielProvider *provider = NULL;
+  g_autoptr (SpielProvider) provider = NULL;
   guint hash = 0;
 
   g_return_val_if_fail (SPIEL_IS_VOICE (self), 0);
@@ -346,6 +346,7 @@ spiel_voice_finalize (GObject *object)
   g_free (priv->name);
   g_free (priv->identifier);
   g_strfreev (priv->languages);
+  g_weak_ref_clear (&priv->provider);
 
   G_OBJECT_CLASS (spiel_voice_parent_class)->finalize (object);
 }
@@ -371,7 +372,7 @@ spiel_voice_get_property (GObject *object,
       g_value_set_boxed (value, priv->languages);
       break;
     case PROP_PROVIDER:
-      g_value_set_object (value, spiel_voice_get_provider (self));
+      g_value_take_object (value, spiel_voice_get_provider (self));
       break;
     case PROP_FEATURES:
       g_value_set_flags (value, priv->features);
@@ -485,4 +486,5 @@ spiel_voice_init (SpielVoice *self)
   priv->languages = NULL;
   priv->output_format = NULL;
   priv->features = 0;
+  g_weak_ref_init (&priv->provider, NULL);
 }

--- a/libspiel/spiel-voice.c
+++ b/libspiel/spiel-voice.c
@@ -108,7 +108,7 @@ spiel_voice_get_identifier (SpielVoice *self)
  *
  * Gets the provider associated with this voice
  *
- * Returns: (transfer none) (nullable): a `SpielProvider`
+ * Returns: (transfer full) (nullable): a `SpielProvider`
  *
  * Since: 1.0
  */

--- a/libspiel/spiel-voice.c
+++ b/libspiel/spiel-voice.c
@@ -75,6 +75,9 @@ const char *
 spiel_voice_get_name (SpielVoice *self)
 {
   SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_VOICE (self), NULL);
+
   return priv->name;
 }
 
@@ -91,6 +94,9 @@ const char *
 spiel_voice_get_identifier (SpielVoice *self)
 {
   SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_VOICE (self), NULL);
+
   return priv->identifier;
 }
 
@@ -106,6 +112,9 @@ SpielProvider *
 spiel_voice_get_provider (SpielVoice *self)
 {
   SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_VOICE (self), NULL);
+
   return g_weak_ref_get (&priv->provider);
 }
 
@@ -122,6 +131,9 @@ const char *const *
 spiel_voice_get_languages (SpielVoice *self)
 {
   SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_VOICE (self), NULL);
+
   return (const char *const *) priv->languages;
 }
 
@@ -129,6 +141,9 @@ SpielVoiceFeature
 spiel_voice_get_features (SpielVoice *self)
 {
   SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_VOICE (self), SPIEL_VOICE_FEATURE_NONE);
+
   return priv->features;
 }
 
@@ -136,6 +151,9 @@ const char *
 spiel_voice_get_output_format (SpielVoice *self)
 {
   SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
+
+  g_return_val_if_fail (SPIEL_IS_VOICE (self), NULL);
+
   return priv->output_format;
 }
 
@@ -143,6 +161,10 @@ void
 spiel_voice_set_output_format (SpielVoice *self, const char *output_format)
 {
   SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
+
+  g_return_if_fail (SPIEL_IS_VOICE (self));
+  g_return_if_fail (output_format != NULL && *output_format != '\0');
+
   g_clear_pointer (&priv->output_format, g_free);
   priv->output_format = g_strdup (output_format);
 }
@@ -151,9 +173,12 @@ guint
 spiel_voice_hash (SpielVoice *self)
 {
   SpielVoicePrivate *priv = spiel_voice_get_instance_private (self);
-  SpielProvider *provider = spiel_voice_get_provider (self);
+  SpielProvider *provider = NULL;
   guint hash = 0;
 
+  g_return_val_if_fail (SPIEL_IS_VOICE (self), 0);
+
+  provider = spiel_voice_get_provider (self);
   hash = g_str_hash (priv->name);
   hash = (hash << 5) - hash + g_str_hash (priv->identifier);
   if (provider)
@@ -175,9 +200,16 @@ spiel_voice_equal (SpielVoice *self, SpielVoice *other)
 {
   SpielVoicePrivate *self_priv = spiel_voice_get_instance_private (self);
   SpielVoicePrivate *other_priv = spiel_voice_get_instance_private (other);
+  g_autoptr (SpielProvider) self_provider = NULL;
+  g_autoptr (SpielProvider) other_provider = NULL;
 
-  if (g_weak_ref_get (&self_priv->provider) !=
-      g_weak_ref_get (&other_priv->provider))
+  g_return_val_if_fail (SPIEL_IS_VOICE (self), FALSE);
+  g_return_val_if_fail (SPIEL_IS_VOICE (other), FALSE);
+
+  self_provider = g_weak_ref_get (&self_priv->provider);
+  other_provider = g_weak_ref_get (&other_priv->provider);
+
+  if (self_provider != other_provider)
     {
       return FALSE;
     }
@@ -206,9 +238,15 @@ spiel_voice_compare (SpielVoice *self, SpielVoice *other, gpointer user_data)
 {
   SpielVoicePrivate *self_priv = spiel_voice_get_instance_private (self);
   SpielVoicePrivate *other_priv = spiel_voice_get_instance_private (other);
-  SpielProvider *self_provider = g_weak_ref_get (&self_priv->provider);
-  SpielProvider *other_provider = g_weak_ref_get (&other_priv->provider);
-  gint cmp = 0;
+  g_autoptr (SpielProvider) self_provider = NULL;
+  g_autoptr (SpielProvider) other_provider = NULL;
+  int cmp = 0;
+
+  g_return_val_if_fail (SPIEL_IS_VOICE (self), 0);
+  g_return_val_if_fail (SPIEL_IS_VOICE (other), 0);
+
+  self_provider = g_weak_ref_get (&self_priv->provider);
+  other_provider = g_weak_ref_get (&other_priv->provider);
 
   if ((cmp = g_strcmp0 (
            self_provider ? spiel_provider_get_well_known_name (self_provider)

--- a/libspiel/spiel-voice.c
+++ b/libspiel/spiel-voice.c
@@ -64,12 +64,13 @@ static GParamSpec *properties[N_PROPS];
 
 /**
  * spiel_voice_get_name: (get-property name)
- * @self: a #SpielVoice
+ * @self: a `SpielVoice`
  *
- * Fetches the name.
+ * Gets the name.
  *
- * Returns: (transfer none): the name text. This string is
- *   owned by the voice and must not be modified or freed.
+ * Returns: (transfer none) (not nullable): the name
+ *
+ * Since: 1.0
  */
 const char *
 spiel_voice_get_name (SpielVoice *self)
@@ -83,12 +84,13 @@ spiel_voice_get_name (SpielVoice *self)
 
 /**
  * spiel_voice_get_identifier: (get-property identifier)
- * @self: a #SpielVoice
+ * @self: a `SpielVoice`
  *
- * Fetches the identifier.
+ * Gets the identifier, unique to [property@Spiel.Voice:provider].
  *
- * Returns: the identifier text. This string is
- *   owned by the voice and must not be modified or freed.
+ * Returns: (transfer none) (not nullable): the identifier
+ *
+ * Since: 1.0
  */
 const char *
 spiel_voice_get_identifier (SpielVoice *self)
@@ -102,11 +104,13 @@ spiel_voice_get_identifier (SpielVoice *self)
 
 /**
  * spiel_voice_get_provider: (get-property provider)
- * @self: a #SpielVoice
+ * @self: a `SpielVoice`
  *
- * Fetches the provider associated with this voice
+ * Gets the provider associated with this voice
  *
- * Returns: (transfer none): a #SpielProvider
+ * Returns: (transfer none) (nullable): a `SpielProvider`
+ *
+ * Since: 1.0
  */
 SpielProvider *
 spiel_voice_get_provider (SpielVoice *self)
@@ -120,12 +124,13 @@ spiel_voice_get_provider (SpielVoice *self)
 
 /**
  * spiel_voice_get_languages: (get-property languages)
- * @self: a #SpielVoice
+ * @self: a `SpielVoice`
  *
- * Fetches the list of supported languages
+ * Gets the list of supported languages.
  *
- * Returns: the list of supported languages. This list is
- *   owned by the voice and must not be modified or freed.
+ * Returns: (transfer none) (not nullable): a list of BCP 47 tags
+ *
+ * Since: 1.0
  */
 const char *const *
 spiel_voice_get_languages (SpielVoice *self)
@@ -137,6 +142,16 @@ spiel_voice_get_languages (SpielVoice *self)
   return (const char *const *) priv->languages;
 }
 
+/**
+ * spiel_voice_get_features: (get-property features)
+ * @self: a `SpielVoice`
+ *
+ * Gets the list of supported features.
+ *
+ * Returns: a bit-field of `SpielVoiceFeature`
+ *
+ * Since: 1.0
+ */
 SpielVoiceFeature
 spiel_voice_get_features (SpielVoice *self)
 {
@@ -147,6 +162,14 @@ spiel_voice_get_features (SpielVoice *self)
   return priv->features;
 }
 
+/**
+ * spiel_voice_get_output_format: (get-property output-format)
+ * @self: a `SpielVoice`
+ *
+ * Gets the output format.
+ *
+ * Since: 1.0
+ */
 const char *
 spiel_voice_get_output_format (SpielVoice *self)
 {
@@ -157,6 +180,15 @@ spiel_voice_get_output_format (SpielVoice *self)
   return priv->output_format;
 }
 
+/**
+ * spiel_voice_set_output_format: (set-property output-format)
+ * @self: a `SpielVoice`
+ * @output_format: (not nullable): an output format string.
+ *
+ * Sets the audio output format.
+ *
+ * Since: 1.0
+ */
 void
 spiel_voice_set_output_format (SpielVoice *self, const char *output_format)
 {
@@ -169,6 +201,16 @@ spiel_voice_set_output_format (SpielVoice *self, const char *output_format)
   priv->output_format = g_strdup (output_format);
 }
 
+/**
+ * spiel_voice_hash:
+ * @self: (not nullable): a `SpielVoice`
+ *
+ * Converts a [class@Spiel.Voice] to a hash value.
+ *
+ * Returns: a hash value corresponding to @self
+ *
+ * Since: 1.0
+ */
 guint
 spiel_voice_hash (SpielVoice *self)
 {
@@ -195,6 +237,17 @@ spiel_voice_hash (SpielVoice *self)
   return hash;
 }
 
+/**
+ * spiel_voice_equal:
+ * @self: (not nullable): a `SpielVoice`
+ * @other: (not nullable): a `SpielVoice` to compare with @self
+ *
+ * Compares the two [class@Spiel.Voice] values and returns %TRUE if equal.
+ *
+ * Returns: %TRUE if the two voices match.
+ *
+ * Since: 1.0
+ */
 gboolean
 spiel_voice_equal (SpielVoice *self, SpielVoice *other)
 {
@@ -233,6 +286,20 @@ spiel_voice_equal (SpielVoice *self, SpielVoice *other)
   return TRUE;
 }
 
+/**
+ * spiel_voice_compare:
+ * @self: (not nullable): a `SpielVoice`
+ * @other: (not nullable): a `SpielVoice` to compare with @self
+ * @user_data: user-defined callback data
+ *
+ * Compares the two [class@Spiel.Voice] values and returns a negative integer
+ * if the first value comes before the second, 0 if they are equal, or a
+ * positive integer if the first value comes after the second.
+ *
+ * Returns: an integer indicating order
+ *
+ * Since: 1.0
+ */
 gint
 spiel_voice_compare (SpielVoice *self, SpielVoice *other, gpointer user_data)
 {

--- a/libspiel/spiel-voices-list-model.c
+++ b/libspiel/spiel-voices-list-model.c
@@ -58,7 +58,9 @@ spiel_voices_list_model_new (GListModel *providers)
   SpielVoicesListModel *self =
       g_object_new (SPIEL_TYPE_VOICES_LIST_MODEL, NULL);
 
+  g_assert (G_IS_LIST_MODEL (providers));
   g_assert_cmpint (g_list_model_get_n_items (providers), ==, 0);
+
   self->providers = g_object_ref (providers);
   g_signal_connect (self->providers, "items-changed",
                     G_CALLBACK (handle_providers_changed), self);

--- a/meson.build
+++ b/meson.build
@@ -79,6 +79,10 @@ foreach arg: test_c_args
 endforeach
 add_project_arguments(project_c_args, language: 'c')
 
+# Synced dependency versions
+glib_version = '>= 2.76'
+gst_version = '>= 1.0'
+
 subdir('libspeechprovider')
 
 if get_option('libspiel')

--- a/utils/spiel.c
+++ b/utils/spiel.c
@@ -64,12 +64,12 @@ do_list_voices (SpielSpeaker *speaker)
     {
       g_autoptr (SpielVoice) voice =
           SPIEL_VOICE (g_list_model_get_object (voices, i));
+      g_autoptr (SpielProvider) provider = spiel_voice_get_provider (voice);
       g_autofree char *languages =
           g_strjoinv (",", (char **) spiel_voice_get_languages (voice));
       g_print ("%-25s %-10s %-10s %s\n", spiel_voice_get_name (voice),
                languages, spiel_voice_get_identifier (voice),
-               spiel_provider_get_well_known_name (
-                   spiel_voice_get_provider (voice)));
+               spiel_provider_get_well_known_name (provider));
     }
 }
 
@@ -129,11 +129,11 @@ find_voice (SpielSpeaker *speaker)
         {
           g_autoptr (SpielVoice) voice =
               SPIEL_VOICE (g_list_model_get_object (voices, i));
+          g_autoptr (SpielProvider) provider = spiel_voice_get_provider (voice);
           if (g_str_equal (voice_id, spiel_voice_get_identifier (voice)) &&
               (!provider_id ||
                g_str_equal (provider_id,
-                            spiel_provider_get_well_known_name (
-                                spiel_voice_get_provider (voice)))))
+                            spiel_provider_get_well_known_name (provider))))
             {
               return g_steal_pointer (&voice);
             }
@@ -210,3 +210,4 @@ main (int argc, char *argv[])
 
   do_speak (speaker, argv[argc - 1]);
 }
+

--- a/utils/spiel.c
+++ b/utils/spiel.c
@@ -210,4 +210,3 @@ main (int argc, char *argv[])
 
   do_speak (speaker, argv[argc - 1]);
 }
-


### PR DESCRIPTION
Fill in a number of things missing, now that Spiel has an initial tag.

- Add pre-condition type checks to public API
- Fix some minor typos
- Update the GI annotations, including memory ownership, symbol versions and others
- Bump the minimum GLib version for the newer C helpers