### PR TITLE
Fixes for pre-conditions and annotation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+  # Runs on pull requests targeting the default branch
+  pull_request:
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/libspeechprovider/speech-provider-stream-reader.c
+++ b/libspeechprovider/speech-provider-stream-reader.c
@@ -138,7 +138,7 @@ _get_next_chunk_type (SpeechProviderStreamReader *self)
 }
 
 /**
- * speech_provider_stream_reader_get_audio: (skip)
+ * speech_provider_stream_reader_get_audio:
  * @self: `SpeechProviderStreamReader`
  * @chunk: (out) (array length=chunk_size) (transfer full) (not nullable):
  *        Location to store audio data
@@ -146,7 +146,7 @@ _get_next_chunk_type (SpeechProviderStreamReader *self)
  *
  * Retrieves audio data
  *
- * Returns: %TRUE if the call succeeds.
+ * Returns: (skip): %TRUE if the call succeeds.
  *
  * Since: 1.0
  */
@@ -179,7 +179,7 @@ speech_provider_stream_reader_get_audio (SpeechProviderStreamReader *self,
 }
 
 /**
- * speech_provider_stream_reader_get_event: (skip)
+ * speech_provider_stream_reader_get_event:
  * @self: a `SpeechProviderStreamReader`
  * @event_type: (out) (not nullable): type of event
  * @range_start: (out) (not nullable): text range start
@@ -188,7 +188,7 @@ speech_provider_stream_reader_get_audio (SpeechProviderStreamReader *self,
  *
  * Retrieves event data
  *
- * Returns: %TRUE if the call succeeds.
+ * Returns: (skip): %TRUE if the call succeeds.
  *
  * Since: 1.0
  */

--- a/libspeechprovider/speech-provider-stream-reader.c
+++ b/libspeechprovider/speech-provider-stream-reader.c
@@ -92,7 +92,7 @@ speech_provider_stream_reader_close (SpeechProviderStreamReader *self)
   SpeechProviderStreamReaderPrivate *priv =
       speech_provider_stream_reader_get_instance_private (self);
 
-  g_return_if_fail (SPEECH_PROVIDER_IS_STREAM_WRITER (self));
+  g_return_if_fail (SPEECH_PROVIDER_IS_STREAM_READER (self));
 
   close (priv->fd);
   priv->fd = -1;
@@ -116,7 +116,7 @@ speech_provider_stream_reader_get_stream_header (
       speech_provider_stream_reader_get_instance_private (self);
   SpeechProviderStreamHeader header;
 
-  g_return_val_if_fail (SPEECH_PROVIDER_IS_STREAM_WRITER (self), FALSE);
+  g_return_val_if_fail (SPEECH_PROVIDER_IS_STREAM_READER (self), FALSE);
   g_assert (!priv->stream_header_received);
 
   read (priv->fd, &header, sizeof (SpeechProviderStreamHeader));
@@ -159,7 +159,7 @@ speech_provider_stream_reader_get_audio (SpeechProviderStreamReader *self,
       speech_provider_stream_reader_get_instance_private (self);
   SpeechProviderChunkType chunk_type = SPEECH_PROVIDER_CHUNK_TYPE_NONE;
 
-  g_return_val_if_fail (SPEECH_PROVIDER_IS_STREAM_WRITER (self), FALSE);
+  g_return_val_if_fail (SPEECH_PROVIDER_IS_STREAM_READER (self), FALSE);
   g_return_val_if_fail (chunk != NULL || *chunk == NULL, FALSE);
   g_return_val_if_fail (chunk_size != NULL, FALSE);
 
@@ -204,7 +204,7 @@ speech_provider_stream_reader_get_event (SpeechProviderStreamReader *self,
   SpeechProviderChunkType chunk_type = _get_next_chunk_type (self);
   SpeechProviderEventData event_data;
 
-  g_return_val_if_fail (SPEECH_PROVIDER_IS_STREAM_WRITER (self), FALSE);
+  g_return_val_if_fail (SPEECH_PROVIDER_IS_STREAM_READER (self), FALSE);
   g_return_val_if_fail (event_type != NULL, FALSE);
   g_return_val_if_fail (range_start != NULL, FALSE);
   g_return_val_if_fail (range_end != NULL, FALSE);

--- a/libspiel/spiel-registry.c
+++ b/libspiel/spiel-registry.c
@@ -583,7 +583,7 @@ spiel_registry_get_voice_for_utterance (SpielRegistry *self,
   SpielVoice *voice = NULL;
 
   g_return_val_if_fail (SPIEL_IS_REGISTRY (self), NULL);
-  g_return_val_if_fail (SPIEL_IS_VOICE (utterance), NULL);
+  g_return_val_if_fail (SPIEL_IS_UTTERANCE (utterance), NULL);
 
   voice = spiel_utterance_get_voice (utterance);
   if (voice)


### PR DESCRIPTION
This fixes several copy-paste errors in the pre-condition checks and annotations, includes in a merge of general cleanups.

The CI is also set to run on pull-requests, to ensure these are caught before merging into `main` when possible.