### PR TITLE
ci: Add test suite based on actuary GitHub action

### DIFF
--- a/.github/workflows/actuary.yml
+++ b/.github/workflows/actuary.yml
@@ -1,0 +1,70 @@
+name: Test Suite (Actuary)
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test (${{ matrix.compiler }}, ${{ matrix.suite }})
+    runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        compiler: [gcc, llvm]
+        suite: [test, asan, analyzer]
+        include:
+          - suite: test
+            setup-args: -Ddocs=false -Dlibspeechprovider:docs=false
+          - suite: asan
+            setup-args: -Ddocs=false -Dlibspeechprovider:docs=false
+          - suite: analyzer
+            setup-args: -Ddocs=false -Dlibspeechprovider:docs=false
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            git meson \
+            libgirepository1.0-dev \
+            dbus libdbus-glib-1-dev \
+            python3-dbusmock python3-tap python3-gi \
+            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            gstreamer1.0-plugins-good \
+            lcov
+
+      - name: Install LLVM
+        if: matrix.compiler == 'llvm'
+        run: |
+          sudo apt-get install -y clang clang-tools
+
+      - name: Test
+        id: test
+        uses: andyholmes/actuary@main
+        with:
+          suite: ${{ matrix.suite }}
+          compiler: ${{ matrix.compiler }}
+          setup-args: ${{ matrix.setup-args }}
+          test-coverage: ${{ matrix.compiler == 'gcc' && matrix.suite == 'test' }}
+
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Logs (${{ matrix.compiler }}, ${{ matrix.suite }})
+          path: ${{ steps.test.outputs.log }}
+
+      - name: Upload coverage
+        if: matrix.compiler == 'gcc' && matrix.suite == 'test'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Coverage Report
+          path: ${{ steps.test.outputs.coverage-html }}


### PR DESCRIPTION
Adds a comprehensive CI workflow using `andyholmes/actuary` as requested in #54.

## Test matrix

|  | gcc | llvm |
|--|-----|------|
| **test** | ✅ (+ coverage) | ✅ |
| **asan** | ✅ | ✅ |
| **analyzer** | ✅ | ✅ |

## Details

- **test**: Standard `meson test` runner. Coverage generation enabled for the gcc variant.
- **asan**: AddressSanitizer for detecting memory errors (use-after-free, buffer overflows, etc.)
- **analyzer**: Static analysis via `scan-build` (clang)

The existing `ci.yml` workflow is preserved for linting (`clang-format`, `python-black`) and basic build verification.

Test logs are uploaded as artifacts on failure, and coverage reports are uploaded for the gcc/test job.

Ref #54